### PR TITLE
Update ExoPlayer to 2.12.0, lint cleanup

### DIFF
--- a/Kuroba/app/build.gradle
+++ b/Kuroba/app/build.gradle
@@ -296,7 +296,9 @@ dependencies {
     implementation "androidx.work:work-runtime-ktx:2.4.0"
     implementation "androidx.lifecycle:lifecycle-runtime-ktx:2.2.0"
     implementation 'com.google.android.material:material:1.2.1'
-    implementation 'com.google.android.exoplayer:exoplayer:2.12.0'
+
+    implementation 'com.google.android.exoplayer:exoplayer-core:2.12.0'
+    implementation 'com.google.android.exoplayer:exoplayer-ui:2.12.0'
     implementation "com.squareup.okhttp3:okhttp:${versions.okhttp}"
     implementation 'org.jsoup:jsoup:1.13.1'
     implementation 'pl.droidsonroids.gif:android-gif-drawable:1.2.21'

--- a/Kuroba/app/build.gradle
+++ b/Kuroba/app/build.gradle
@@ -297,8 +297,8 @@ dependencies {
     implementation "androidx.lifecycle:lifecycle-runtime-ktx:2.2.0"
     implementation "com.google.android.material:material:${versions.material}"
 
-    implementation 'com.google.android.exoplayer:exoplayer-core:2.12.0'
-    implementation 'com.google.android.exoplayer:exoplayer-ui:2.12.0'
+    implementation "com.google.android.exoplayer:exoplayer-core:${versions.exoplayer}"
+    implementation "com.google.android.exoplayer:exoplayer-ui:${versions.exoplayer}"
     implementation "com.squareup.okhttp3:okhttp:${versions.okhttp}"
     implementation 'org.jsoup:jsoup:1.13.1'
     implementation 'pl.droidsonroids.gif:android-gif-drawable:1.2.21'

--- a/Kuroba/app/build.gradle
+++ b/Kuroba/app/build.gradle
@@ -295,7 +295,7 @@ dependencies {
     implementation "androidx.core:core-ktx:${versions.core_ktx}"
     implementation "androidx.work:work-runtime-ktx:2.4.0"
     implementation "androidx.lifecycle:lifecycle-runtime-ktx:2.2.0"
-    implementation 'com.google.android.material:material:1.2.1'
+    implementation "com.google.android.material:material:${versions.material}"
 
     implementation 'com.google.android.exoplayer:exoplayer-core:2.12.0'
     implementation 'com.google.android.exoplayer:exoplayer-ui:2.12.0'
@@ -310,7 +310,7 @@ dependencies {
     implementation 'com.vladsch.flexmark:flexmark:0.60.2'
     implementation 'io.reactivex.rxjava2:rxjava:2.2.19'
     implementation 'io.reactivex.rxjava2:rxandroid:2.1.1'
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${versions.kotlin_version}"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:${versions.kotlin_version}"
     implementation "joda-time:joda-time:${versions.joda_time}"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:${versions.kotlin_coroutines_version}"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:${versions.kotlin_coroutines_version}"

--- a/Kuroba/app/src/main/java/com/github/k1rakishou/chan/core/cache/stream/WebmStreamingDataSource.java
+++ b/Kuroba/app/src/main/java/com/github/k1rakishou/chan/core/cache/stream/WebmStreamingDataSource.java
@@ -256,7 +256,12 @@ public class WebmStreamingDataSource extends BaseDataSource {
     }
 
     private void detectLength() throws HttpDataSource.HttpDataSourceException {
-        this.fileLength = dataSource.open(new DataSpec(uri, 0, C.LENGTH_UNSET, null));
+        this.fileLength = dataSource.open(new DataSpec.Builder()
+                .setUri(uri)
+                .setPosition(0)
+                .setLength(C.LENGTH_UNSET)
+                .setKey(null)
+                .build());
 
         if (verboseLogs) {
             Logger.i(TAG, "detectLength: " + this.fileLength);
@@ -339,12 +344,12 @@ public class WebmStreamingDataSource extends BaseDataSource {
             // our DataSpec was supposed to read, it's okay to assume we will read the entirety
             // of our missing ranges, and we won't need to seek inside them.
 
-            DataSpec dataSpec = new DataSpec(
-                    uri,
-                    range.getLower(),
-                    range.getUpper() - range.getLower() + 1,
-                    null
-            );
+            DataSpec dataSpec = new DataSpec.Builder()
+                    .setUri(uri)
+                    .setPosition(range.getLower())
+                    .setLength(range.getUpper() - range.getLower() + 1)
+                    .setKey(null)
+                    .build();
 
             dataSource.open(dataSpec);
             httpActiveRange = range;

--- a/Kuroba/app/src/main/java/com/github/k1rakishou/chan/core/cache/stream/WebmStreamingSource.kt
+++ b/Kuroba/app/src/main/java/com/github/k1rakishou/chan/core/cache/stream/WebmStreamingSource.kt
@@ -13,8 +13,8 @@ import com.github.k1rakishou.chan.utils.Logger
 import com.github.k1rakishou.fsaf.FileManager
 import com.github.k1rakishou.fsaf.file.AbstractFile
 import com.github.k1rakishou.fsaf.file.RawFile
+import com.google.android.exoplayer2.MediaItem
 import com.google.android.exoplayer2.source.ProgressiveMediaSource
-import com.google.android.exoplayer2.upstream.DataSource
 import com.google.android.exoplayer2.upstream.FileDataSource
 import java.io.IOException
 
@@ -67,7 +67,7 @@ class WebmStreamingSource(
           // The webm file is already completely downloaded, just use it from the disk
           callback.onMediaSourceReady(
             ProgressiveMediaSource.Factory { fileCacheSource }
-              .createMediaSource(uri)
+              .createMediaSource(MediaItem.Builder().setUri(uri).build())
           )
         }
 
@@ -130,8 +130,8 @@ class WebmStreamingSource(
     }
 
     callback.onMediaSourceReady(
-      ProgressiveMediaSource.Factory(DataSource.Factory { fileCacheSource })
-        .createMediaSource(uri)
+      ProgressiveMediaSource.Factory { fileCacheSource }
+        .createMediaSource(MediaItem.Builder().setUri(uri).build())
     )
   }
 
@@ -140,8 +140,8 @@ class WebmStreamingSource(
     val fileUri = Uri.parse(rawFile.getFullPath())
 
     callback.onMediaSourceReady(
-      ProgressiveMediaSource.Factory(DataSource.Factory { FileDataSource() })
-        .createMediaSource(fileUri)
+      ProgressiveMediaSource.Factory { FileDataSource() }
+        .createMediaSource(MediaItem.Builder().setUri(fileUri).build())
     )
   }
 

--- a/Kuroba/app/src/main/java/com/github/k1rakishou/chan/ui/view/MultiImageView.kt
+++ b/Kuroba/app/src/main/java/com/github/k1rakishou/chan/ui/view/MultiImageView.kt
@@ -71,6 +71,7 @@ import com.github.k1rakishou.common.*
 import com.github.k1rakishou.fsaf.file.RawFile
 import com.github.k1rakishou.model.data.descriptor.ChanDescriptor
 import com.github.k1rakishou.model.data.post.ChanPostImageType
+import com.google.android.exoplayer2.MediaItem
 import com.google.android.exoplayer2.Player
 import com.google.android.exoplayer2.SimpleExoPlayer
 import com.google.android.exoplayer2.audio.AudioListener
@@ -689,7 +690,8 @@ class MultiImageView @JvmOverloads constructor(
       val userAgent = Util.getUserAgent(AndroidUtils.getAppContext(), AppConstants.USER_AGENT)
       val dataSourceFactory: DataSource.Factory = DefaultDataSourceFactory(context, userAgent)
       val progressiveFactory = ProgressiveMediaSource.Factory(dataSourceFactory)
-      val videoSource = progressiveFactory.createMediaSource(Uri.fromFile(file))
+      val videoSource = progressiveFactory.createMediaSource(
+              MediaItem.Builder().setUri(Uri.fromFile(file)).build())
 
       exoPlayer = createExoPlayer(videoSource)
 
@@ -819,7 +821,8 @@ class MultiImageView @JvmOverloads constructor(
 
   private fun createExoPlayer(source: MediaSource): SimpleExoPlayer {
     return SimpleExoPlayer.Builder(context).build().apply {
-      prepare(source)
+      setMediaSource(source)
+      prepare()
 
       repeatMode = if (ChanSettings.videoAutoLoop.get()) {
         Player.REPEAT_MODE_ALL

--- a/Kuroba/core-common/build.gradle
+++ b/Kuroba/core-common/build.gradle
@@ -21,11 +21,18 @@ android {
         android {
         }
     }
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+    kotlinOptions {
+        jvmTarget = '1.8'
+    }
 }
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${versions.kotlin_version}"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:${versions.kotlin_version}"
 
     implementation "com.squareup.okhttp3:okhttp:${versions.okhttp}"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:${versions.kotlin_coroutines_version}"

--- a/Kuroba/core-model/build.gradle
+++ b/Kuroba/core-model/build.gradle
@@ -27,6 +27,13 @@ android {
         android {
         }
     }
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+    kotlinOptions {
+        jvmTarget = '1.8'
+    }
 }
 
 dependencies {
@@ -34,7 +41,7 @@ dependencies {
     implementation project(':core-settings')
 
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${versions.kotlin_version}"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:${versions.kotlin_version}"
     implementation "androidx.appcompat:appcompat:${versions.appcompat}"
     implementation "androidx.core:core-ktx:${versions.core_ktx}"
     implementation "joda-time:joda-time:${versions.joda_time}"

--- a/Kuroba/core-settings/build.gradle
+++ b/Kuroba/core-settings/build.gradle
@@ -38,9 +38,9 @@ dependencies {
     implementation project(path: ':core-common')
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib:${versions.kotlin_version}"
-    implementation 'androidx.core:core-ktx:1.3.1'
-    implementation 'androidx.appcompat:appcompat:1.2.0'
-    implementation 'com.google.android.material:material:1.2.1'
+    implementation "androidx.core:core-ktx:${versions.core_ktx}"
+    implementation "androidx.appcompat:appcompat:${versions.appcompat}"
+    implementation "com.google.android.material:material:${versions.material}"
 
     implementation "com.google.code.gson:gson:${versions.gson}"
 }

--- a/Kuroba/gradle.properties
+++ b/Kuroba/gradle.properties
@@ -1,3 +1,4 @@
 android.enableJetifier=true
 android.useAndroidX=true
+kotlin.code.style=official
 org.gradle.jvmargs=-Xmx2048M

--- a/Kuroba/versions.gradle
+++ b/Kuroba/versions.gradle
@@ -4,6 +4,7 @@ versions.kotlin_coroutines_version = '1.3.9'
 versions.room_version = "2.2.5"
 versions.dagger_version = '2.29.1'
 versions.okhttp = "4.9.0"
+versions.exoplayer = "2.12.0"
 versions.joda_time = "2.10.6"
 versions.appcompat = "1.2.0"
 versions.core_ktx = '1.3.1'

--- a/Kuroba/versions.gradle
+++ b/Kuroba/versions.gradle
@@ -7,6 +7,7 @@ versions.okhttp = "4.9.0"
 versions.joda_time = "2.10.6"
 versions.appcompat = "1.2.0"
 versions.core_ktx = '1.3.1'
+versions.material = "1.2.1"
 versions.gson = "2.8.6"
 versions.junit = "4.13"
 versions.robolectric = '4.4'


### PR DESCRIPTION
- Update ExoPlayer to 2.12.0 ([changelog](https://github.com/google/ExoPlayer/blob/release-v2/RELEASENOTES.md)) (I'm pretty sure I did it right)
- Made gradles better match each other
- Lint-rolled the codebase, and some other little cleanups
- Set use of official Kotlin codestyle in gradle.properties (I'll let you reformat if you want)

Hope you like it.

(I know the ExoPlayer implementation is gonna be changed in a bit due to https://github.com/K1rakishou/Kuroba-Experimental/issues/133, but I figured I would update it anyway.)