### PR TITLE
Avoid thread watching

### DIFF
--- a/Kuroba/app/src/main/java/com/github/k1rakishou/chan/core/di/module/application/UseCaseModule.java
+++ b/Kuroba/app/src/main/java/com/github/k1rakishou/chan/core/di/module/application/UseCaseModule.java
@@ -21,6 +21,7 @@ import com.github.k1rakishou.chan.core.manager.SeenPostsManager;
 import com.github.k1rakishou.chan.core.manager.SiteManager;
 import com.github.k1rakishou.chan.core.manager.ThirdEyeManager;
 import com.github.k1rakishou.chan.core.manager.ThreadBookmarkGroupManager;
+import com.github.k1rakishou.chan.core.manager.ThreadDownloadManager;
 import com.github.k1rakishou.chan.core.site.loader.ChanThreadLoaderCoordinator;
 import com.github.k1rakishou.chan.core.site.loader.internal.usecase.ParsePostsV1UseCase;
 import com.github.k1rakishou.chan.core.site.parser.ReplyParser;
@@ -192,6 +193,7 @@ public class UseCaseModule {
             CoroutineScope appScope,
             BoardManager boardManager,
             BookmarksManager bookmarksManager,
+            Lazy<ThreadDownloadManager> threadDownloadManager,
             ThreadBookmarkGroupManager threadBookmarkGroupManager,
             ChanFilterManager chanFilterManager,
             SiteManager siteManager,
@@ -207,6 +209,7 @@ public class UseCaseModule {
                 appConstants,
                 boardManager,
                 bookmarksManager,
+                threadDownloadManager,
                 threadBookmarkGroupManager,
                 chanFilterManager,
                 siteManager,

--- a/Kuroba/app/src/main/java/com/github/k1rakishou/chan/core/manager/ChanFilterManager.kt
+++ b/Kuroba/app/src/main/java/com/github/k1rakishou/chan/core/manager/ChanFilterManager.kt
@@ -542,6 +542,8 @@ class ChanFilterManager(
       applyToSaved = newChanFilter.applyToSaved,
       applyToEmptyComments = newChanFilter.applyToEmptyComments,
       filterWatchNotify = newChanFilter.filterWatchNotify,
+      filterWatchAutoSave = newChanFilter.filterWatchAutoSave,
+      filterWatchAutoSaveMedia = newChanFilter.filterWatchAutoSaveMedia,
     )
   }
 

--- a/Kuroba/app/src/main/java/com/github/k1rakishou/chan/core/site/loader/internal/usecase/AbstractParsePostsUseCase.kt
+++ b/Kuroba/app/src/main/java/com/github/k1rakishou/chan/core/site/loader/internal/usecase/AbstractParsePostsUseCase.kt
@@ -89,7 +89,7 @@ abstract class AbstractParsePostsUseCase(
     }
 
     for (filter in filters) {
-      if (filter.isWatchFilter()) {
+      if (filter.isWatchFilter() || filter.isAvoidWatchFilter()) {
         // Do not auto create watch filters, this may end up pretty bad
         continue
       }
@@ -136,6 +136,9 @@ abstract class AbstractParsePostsUseCase(
       }
       FilterAction.WATCH -> {
         throw IllegalStateException("Cannot auto-create WATCH filters")
+      }
+      FilterAction.AVOID_WATCH -> {
+        throw IllegalStateException("Cannot auto-create AVOID_WATCH filters")
       }
     }
   }

--- a/Kuroba/app/src/main/java/com/github/k1rakishou/chan/core/usecase/BookmarkFilterWatchableThreadsUseCase.kt
+++ b/Kuroba/app/src/main/java/com/github/k1rakishou/chan/core/usecase/BookmarkFilterWatchableThreadsUseCase.kt
@@ -388,12 +388,20 @@ class BookmarkFilterWatchableThreadsUseCase(
 
       if (filterEngine.typeMatches(watchFilter, FilterType.COMMENT)) {
         if (filterEngine.matches(watchFilter, parsedComment, false)) {
+          if (watchFilter.isAvoidWatchFilter())
+          {
+            return null;
+          }
           return watchFilter
         }
       }
 
       if (filterEngine.typeMatches(watchFilter, FilterType.SUBJECT)) {
         if (filterEngine.matches(watchFilter, subject, false)) {
+          if (watchFilter.isAvoidWatchFilter())
+          {
+            return null;
+          }
           return watchFilter
         }
       }

--- a/Kuroba/app/src/main/java/com/github/k1rakishou/chan/core/usecase/KurobaSettingsImportUseCase.kt
+++ b/Kuroba/app/src/main/java/com/github/k1rakishou/chan/core/usecase/KurobaSettingsImportUseCase.kt
@@ -478,7 +478,7 @@ class KurobaSettingsImportUseCase(
             return@jsonObject
           }
 
-          if (action == FilterAction.WATCH.id) {
+          if (action == FilterAction.WATCH.id || action == FilterAction.AVOID_WATCH.id) {
             Logger.e(TAG, "readFilters() Skipping WATCH filter")
             return@jsonObject
           }

--- a/Kuroba/app/src/main/java/com/github/k1rakishou/chan/features/filters/CreateOrUpdateFilterController.kt
+++ b/Kuroba/app/src/main/java/com/github/k1rakishou/chan/features/filters/CreateOrUpdateFilterController.kt
@@ -215,6 +215,8 @@ class CreateOrUpdateFilterController(
     var applyToSaved by remember { chanFilterMutableState.applyToSaved }
     var applyToEmptyComments by remember { chanFilterMutableState.applyToEmptyComments }
     var filterWatchNotify by remember { chanFilterMutableState.filterWatchNotify }
+    var filterWatchAutoSave by remember { chanFilterMutableState.filterWatchAutoSave }
+    var filterWatchAutoSaveMedia by remember { chanFilterMutableState.filterWatchAutoSaveMedia }
     val arrowDropDownDrawable = remember { getTextDrawableContent() }
 
     if (action == FilterAction.WATCH.id) {
@@ -783,6 +785,8 @@ class CreateOrUpdateFilterController(
     val applyToSaved: MutableState<Boolean> = mutableStateOf(false),
     val applyToEmptyComments: MutableState<Boolean> = mutableStateOf(false),
     val filterWatchNotify: MutableState<Boolean> = mutableStateOf(false),
+    val filterWatchAutoSave: MutableState<Boolean> = mutableStateOf(false),
+    val filterWatchAutoSaveMedia: MutableState<Boolean> = mutableStateOf(false),
 
     val testPattern: MutableState<String> = mutableStateOf(""),
     val filterValidationResult: MutableState<FilterValidationResult> = mutableStateOf(FilterValidationResult.Undefined)
@@ -804,6 +808,8 @@ class CreateOrUpdateFilterController(
         applyToSaved = applyToSaved.value,
         applyToEmptyComments = applyToEmptyComments.value,
         filterWatchNotify = filterWatchNotify.value,
+        filterWatchAutoSave = filterWatchAutoSave.value,
+        filterWatchAutoSaveMedia = filterWatchAutoSaveMedia.value,
       )
     }
 
@@ -824,6 +830,8 @@ class CreateOrUpdateFilterController(
           chanFilterMutableState.applyToSaved.value = chanFilterMutable.applyToSaved
           chanFilterMutableState.applyToEmptyComments.value = chanFilterMutable.applyToEmptyComments
           chanFilterMutableState.filterWatchNotify.value = chanFilterMutable.filterWatchNotify
+          chanFilterMutableState.filterWatchAutoSave.value = chanFilterMutable.filterWatchAutoSave
+          chanFilterMutableState.filterWatchAutoSaveMedia.value = chanFilterMutable.filterWatchAutoSaveMedia
 
           chanFilterMutableState.color.value = if (chanFilterMutable.color != 0) {
             chanFilterMutable.color

--- a/Kuroba/app/src/main/java/com/github/k1rakishou/chan/features/filters/CreateOrUpdateFilterController.kt
+++ b/Kuroba/app/src/main/java/com/github/k1rakishou/chan/features/filters/CreateOrUpdateFilterController.kt
@@ -402,6 +402,26 @@ class CreateOrUpdateFilterController(
         currentlyChecked = filterWatchNotify,
         onCheckChanged = { checked -> filterWatchNotify = checked }
       )
+
+      KurobaComposeCheckbox(
+        modifier = Modifier
+          .fillMaxWidth()
+          .wrapContentHeight(),
+        text = stringResource(id = R.string.filter_watcher_auto_save),
+        enabled = true,
+        currentlyChecked = filterWatchAutoSave,
+        onCheckChanged = { checked -> filterWatchAutoSave = checked }
+      )
+
+      KurobaComposeCheckbox(
+        modifier = Modifier
+          .fillMaxWidth()
+          .wrapContentHeight(),
+        text = stringResource(id = R.string.filter_watcher_auto_save_media),
+        enabled = filterWatchAutoSave,
+        currentlyChecked = filterWatchAutoSaveMedia,
+        onCheckChanged = { checked -> filterWatchAutoSaveMedia = checked }
+      )
     }
 
     if (action != FilterAction.WATCH.id) {

--- a/Kuroba/app/src/main/java/com/github/k1rakishou/chan/features/filters/CreateOrUpdateFilterController.kt
+++ b/Kuroba/app/src/main/java/com/github/k1rakishou/chan/features/filters/CreateOrUpdateFilterController.kt
@@ -217,7 +217,7 @@ class CreateOrUpdateFilterController(
     var filterWatchNotify by remember { chanFilterMutableState.filterWatchNotify }
     val arrowDropDownDrawable = remember { getTextDrawableContent() }
 
-    if (action == FilterAction.WATCH.id) {
+    if (action == FilterAction.WATCH.id || action == FilterAction.AVOID_WATCH.id  ) {
       applyToReplies = false
       applyToSaved = false
       applyToEmptyComments = false
@@ -385,7 +385,7 @@ class CreateOrUpdateFilterController(
         .fillMaxWidth()
         .wrapContentHeight(),
       text = stringResource(id = R.string.filter_only_on_op),
-      enabled = action != FilterAction.WATCH.id,
+      enabled = action != FilterAction.WATCH.id && action != FilterAction.AVOID_WATCH.id,
       currentlyChecked = onlyOnOP,
       onCheckChanged = { checked -> onlyOnOP = checked }
     )
@@ -402,7 +402,7 @@ class CreateOrUpdateFilterController(
       )
     }
 
-    if (action != FilterAction.WATCH.id) {
+    if (action != FilterAction.WATCH.id && action != FilterAction.AVOID_WATCH.id) {
       KurobaComposeCheckbox(
         modifier = Modifier
           .fillMaxWidth()

--- a/Kuroba/app/src/main/java/com/github/k1rakishou/chan/features/filters/FiltersControllerViewModel.kt
+++ b/Kuroba/app/src/main/java/com/github/k1rakishou/chan/features/filters/FiltersControllerViewModel.kt
@@ -379,16 +379,35 @@ class FiltersControllerViewModel : BaseViewModel() {
         append(chanFilter.applyToEmptyComments.toString())
       }
 
-      if (chanFilter.isWatchFilter() && chanFilter.filterWatchNotify) {
-        append("\n")
-        append(
-          AnnotatedString(getString(R.string.filter_filter_watch_notify),
-            SpanStyle(color = chanTheme.textColorSecondaryCompose))
-        )
-        append(" ")
-        append(chanFilter.filterWatchNotify.toString())
+      if (chanFilter.isWatchFilter()) {
+        if (chanFilter.filterWatchNotify) {
+          append("\n")
+          append(
+            AnnotatedString(getString(R.string.filter_filter_watch_notify),
+              SpanStyle(color = chanTheme.textColorSecondaryCompose))
+          )
+          append(" ")
+          append(chanFilter.filterWatchNotify.toString())
+        }
+        if (chanFilter.filterWatchAutoSave){
+          append("\n")
+          append(
+            AnnotatedString(getString(R.string.filter_filter_watch_auto_save),
+              SpanStyle(color = chanTheme.textColorSecondaryCompose))
+          )
+          append(" ")
+          append(chanFilter.filterWatchAutoSave.toString())
+        }
+        if (chanFilter.filterWatchAutoSaveMedia){
+          append("\n")
+          append(
+            AnnotatedString(getString(R.string.filter_filter_watch_auto_save_media),
+              SpanStyle(color = chanTheme.textColorSecondaryCompose))
+          )
+          append(" ")
+          append(chanFilter.filterWatchAutoSaveMedia.toString())
+        }
       }
-
       val filterNote = chanFilter.note
       if (filterNote.isNotNullNorBlank()) {
         append("\n")

--- a/Kuroba/app/src/main/res/values/strings.xml
+++ b/Kuroba/app/src/main/res/values/strings.xml
@@ -305,9 +305,13 @@ Re-enable this permission in the app settings if you permanently disabled it."</
     <string name="filter_apply_to_replies">Apply to replies</string>
     <string name="filter_only_on_op">Only apply to OP</string>
     <string name="filter_watcher_notify">Notify when bookmarks created</string>
+    <string name="filter_watcher_auto_save">Automatically save bookmarked thread</string>
+    <string name="filter_watcher_auto_save_media">Download bookmarked thread media</string>
     <string name="filter_apply_to_own_posts">Apply to my own posts</string>
     <string name="filter_apply_to_post_with_empty_comment">Apply to posts with empty comment</string>
     <string name="filter_filter_watch_notify">Notify on new matched threads</string>
+    <string name="filter_filter_watch_auto_save">Automatically save bookmarked thread</string>
+    <string name="filter_filter_watch_auto_save_media">Download bookmarked thread media</string>
     <string name="filter_filter_type_group">Filter type:</string>
     <string name="filter_boards_group">Boards:</string>
     <string name="filter_action_group">Action:</string>

--- a/Kuroba/core-model/src/main/java/com/github/k1rakishou/model/KurobaDatabase.kt
+++ b/Kuroba/core-model/src/main/java/com/github/k1rakishou/model/KurobaDatabase.kt
@@ -105,6 +105,7 @@ import com.github.k1rakishou.model.migrations.Migration_v38_to_v39
 import com.github.k1rakishou.model.migrations.Migration_v39_to_v40
 import com.github.k1rakishou.model.migrations.Migration_v3_to_v4
 import com.github.k1rakishou.model.migrations.Migration_v40_to_v41
+import com.github.k1rakishou.model.migrations.Migration_v41_to_v42
 import com.github.k1rakishou.model.migrations.Migration_v4_to_v5
 import com.github.k1rakishou.model.migrations.Migration_v5_to_v6
 import com.github.k1rakishou.model.migrations.Migration_v6_to_v7
@@ -152,7 +153,7 @@ import java.util.concurrent.atomic.AtomicInteger
     ChanThreadsWithPosts::class,
     OldChanPostThread::class
   ],
-  version = 41,
+  version = 42,
   exportSchema = true
 )
 @TypeConverters(
@@ -285,6 +286,7 @@ abstract class KurobaDatabase : RoomDatabase() {
           Migration_v38_to_v39(),
           Migration_v39_to_v40(),
           Migration_v40_to_v41(),
+          Migration_v41_to_v42(),
         )
         .fallbackToDestructiveMigrationOnDowngrade()
         .build()

--- a/Kuroba/core-model/src/main/java/com/github/k1rakishou/model/data/filter/ChanFilter.kt
+++ b/Kuroba/core-model/src/main/java/com/github/k1rakishou/model/data/filter/ChanFilter.kt
@@ -38,7 +38,7 @@ class ChanFilter(
   }
 
   fun isEnabledWatchFilter(): Boolean {
-    return enabled && isWatchFilter()
+    return enabled && (isWatchFilter() || isAvoidWatchFilter())
   }
 
   fun isEnabledHighlightFilter(): Boolean {
@@ -47,6 +47,10 @@ class ChanFilter(
 
   fun isWatchFilter(): Boolean {
     return action == FilterAction.WATCH.id
+  }
+
+  fun isAvoidWatchFilter(): Boolean {
+    return action == FilterAction.AVOID_WATCH.id
   }
 
   fun isHighlightFilter(): Boolean {

--- a/Kuroba/core-model/src/main/java/com/github/k1rakishou/model/data/filter/ChanFilter.kt
+++ b/Kuroba/core-model/src/main/java/com/github/k1rakishou/model/data/filter/ChanFilter.kt
@@ -15,7 +15,9 @@ class ChanFilter(
   val onlyOnOP: Boolean = false,
   val applyToSaved: Boolean = false,
   val applyToEmptyComments: Boolean = false,
-  val filterWatchNotify: Boolean = false
+  val filterWatchNotify: Boolean = false,
+  val filterWatchAutoSave: Boolean = false,
+  val filterWatchAutoSaveMedia: Boolean = false
 ) {
 
   @Synchronized
@@ -35,6 +37,22 @@ class ChanFilter(
     }
 
     return filterWatchNotify
+  }
+
+  fun filterWatcherAutoSaveThread(): Boolean {
+    if (action != FilterAction.WATCH.id) {
+      return false
+    }
+
+    return filterWatchAutoSave
+  }
+
+  fun filterWatcherAutoSaveThreadMedia(): Boolean {
+    if (action != FilterAction.WATCH.id || !filterWatchAutoSave) {
+      return false
+    }
+
+    return filterWatchAutoSaveMedia
   }
 
   fun isEnabledWatchFilter(): Boolean {
@@ -78,6 +96,8 @@ class ChanFilter(
       applyToSaved = applyToSaved,
       applyToEmptyComments = applyToEmptyComments,
       filterWatchNotify = filterWatchNotify,
+      filterWatchAutoSave = filterWatchAutoSave,
+      filterWatchAutoSaveMedia = filterWatchAutoSaveMedia,
     )
   }
 
@@ -100,6 +120,8 @@ class ChanFilter(
     if (applyToSaved != other.applyToSaved) return false
     if (applyToEmptyComments != other.applyToEmptyComments) return false
     if (filterWatchNotify != other.filterWatchNotify) return false
+    if (filterWatchAutoSave != other.filterWatchAutoSave) return false
+    if (filterWatchAutoSaveMedia != other.filterWatchAutoSaveMedia) return false
 
     return true
   }
@@ -118,6 +140,8 @@ class ChanFilter(
     result = 31 * result + applyToSaved.hashCode()
     result = 31 * result + applyToEmptyComments.hashCode()
     result = 31 * result + filterWatchNotify.hashCode()
+    result = 31 * result + filterWatchAutoSave.hashCode()
+    result = 31 * result + filterWatchAutoSaveMedia.hashCode()
     return result
   }
 
@@ -125,7 +149,7 @@ class ChanFilter(
     return "ChanFilter(filterDatabaseId=$filterDatabaseId, enabled=$enabled, type=$type, " +
       "pattern=$pattern, boards=$boards, action=$action, color=$color, note=$note" +
       "applyToReplies=$applyToReplies, onlyOnOP=$onlyOnOP, applyToSaved=$applyToSaved, " +
-      "applyToEmptyComments=$applyToEmptyComments, filterWatchNotify=$filterWatchNotify)"
+      "applyToEmptyComments=$applyToEmptyComments, filterWatchNotify=$filterWatchNotify), filterWatchAutoSave=$filterWatchAutoSave, filterWatchAutoSaveMedia=$filterWatchAutoSaveMedia)"
   }
 
 }

--- a/Kuroba/core-model/src/main/java/com/github/k1rakishou/model/data/filter/ChanFilterMutable.kt
+++ b/Kuroba/core-model/src/main/java/com/github/k1rakishou/model/data/filter/ChanFilterMutable.kt
@@ -26,7 +26,7 @@ class ChanFilterMutable(
   fun allBoards(): Boolean = allBoardsSelected && boards.isEmpty()
 
   fun isWatchFilter(): Boolean {
-    return action == FilterAction.WATCH.id
+    return action == FilterAction.WATCH.id || action == FilterAction.AVOID_WATCH.id
   }
 
   fun applyToBoards(allBoardsChecked: Boolean, boards: List<ChanBoard>) {

--- a/Kuroba/core-model/src/main/java/com/github/k1rakishou/model/data/filter/ChanFilterMutable.kt
+++ b/Kuroba/core-model/src/main/java/com/github/k1rakishou/model/data/filter/ChanFilterMutable.kt
@@ -17,7 +17,9 @@ class ChanFilterMutable(
   var onlyOnOP: Boolean = false,
   var applyToSaved: Boolean = false,
   var applyToEmptyComments: Boolean = false,
-  var filterWatchNotify: Boolean = false
+  var filterWatchNotify: Boolean = false,
+  var filterWatchAutoSave: Boolean = false,
+  var filterWatchAutoSaveMedia: Boolean = false
 ) {
   fun matchesBoard(boardDescriptor: BoardDescriptor): Boolean {
     return allBoards() || boards.contains(boardDescriptor)
@@ -68,6 +70,8 @@ class ChanFilterMutable(
       applyToSaved = this.applyToSaved,
       applyToEmptyComments = this.applyToEmptyComments,
       filterWatchNotify = this.filterWatchNotify,
+      filterWatchAutoSave = this.filterWatchAutoSave,
+      filterWatchAutoSaveMedia = this.filterWatchAutoSaveMedia,
     )
   }
 
@@ -88,6 +92,8 @@ class ChanFilterMutable(
         applyToSaved = chanFilter.applyToSaved,
         applyToEmptyComments = chanFilter.applyToEmptyComments,
         filterWatchNotify = chanFilter.filterWatchNotify,
+        filterWatchAutoSave = chanFilter.filterWatchAutoSave,
+        filterWatchAutoSaveMedia = chanFilter.filterWatchAutoSaveMedia,
       ).also { chanFilterMutable ->
         chanFilterMutable.boards.clear()
         chanFilterMutable.boards.addAll(chanFilter.boards)

--- a/Kuroba/core-model/src/main/java/com/github/k1rakishou/model/data/filter/FilterAction.java
+++ b/Kuroba/core-model/src/main/java/com/github/k1rakishou/model/data/filter/FilterAction.java
@@ -4,7 +4,8 @@ public enum FilterAction {
     HIDE(0),
     COLOR(1),
     REMOVE(2),
-    WATCH(3);
+    WATCH(3),
+    AVOID_WATCH(4);
 
     public final int id;
 
@@ -16,7 +17,7 @@ public enum FilterAction {
         return enums[id];
     }
 
-    private static FilterAction[] enums = new FilterAction[4];
+    private static FilterAction[] enums = new FilterAction[FilterAction.values().length];
 
     public static String filterActionName(FilterAction action) {
         switch (action) {
@@ -28,6 +29,8 @@ public enum FilterAction {
                 return "Remove post";
             case WATCH:
                 return "Watch post";
+            case AVOID_WATCH:
+                return "Avoid watching post";
         }
 
         return "Unknown action (" + action.id + ")";

--- a/Kuroba/core-model/src/main/java/com/github/k1rakishou/model/entity/chan/filter/ChanFilterEntity.kt
+++ b/Kuroba/core-model/src/main/java/com/github/k1rakishou/model/entity/chan/filter/ChanFilterEntity.kt
@@ -33,7 +33,11 @@ data class ChanFilterEntity(
   @ColumnInfo(name = APPLY_TO_POSTS_WITH_EMPTY_COMMENT)
   val applyToEmptyComments: Boolean = false,
   @ColumnInfo(name = FILTER_WATCH_NOTIFY_COLUMN_NAME)
-  val filterWatchNotify: Boolean = false
+  val filterWatchNotify: Boolean = false,
+  @ColumnInfo(name = FILTER_WATCH_AUTO_SAVE_COLUMN_NAME)
+  val filterWatchAutoSave: Boolean = false,
+  @ColumnInfo(name = FILTER_WATCH_AUTO_SAVE_MEDIA_COLUMN_NAME)
+  val filterWatchAutoSaveMedia: Boolean = false
 ) {
 
   companion object {
@@ -52,5 +56,7 @@ data class ChanFilterEntity(
     const val APPLY_TO_SAVED_COLUMN_NAME = "apply_to_saved"
     const val APPLY_TO_POSTS_WITH_EMPTY_COMMENT = "apply_to_posts_with_empty_comment"
     const val FILTER_WATCH_NOTIFY_COLUMN_NAME = "filter_watch_notify"
+    const val FILTER_WATCH_AUTO_SAVE_COLUMN_NAME = "filter_watch_autosave"
+    const val FILTER_WATCH_AUTO_SAVE_MEDIA_COLUMN_NAME = "filter_watch_autosave_media"
   }
 }

--- a/Kuroba/core-model/src/main/java/com/github/k1rakishou/model/mapper/ChanFilterMapper.kt
+++ b/Kuroba/core-model/src/main/java/com/github/k1rakishou/model/mapper/ChanFilterMapper.kt
@@ -30,6 +30,8 @@ object ChanFilterMapper {
       applyToSaved = chanFilterFull.chanFilterEntity.applyToSaved,
       applyToEmptyComments = chanFilterFull.chanFilterEntity.applyToEmptyComments,
       filterWatchNotify = chanFilterFull.chanFilterEntity.filterWatchNotify,
+      filterWatchAutoSave = chanFilterFull.chanFilterEntity.filterWatchAutoSave,
+      filterWatchAutoSaveMedia = chanFilterFull.chanFilterEntity.filterWatchAutoSaveMedia,
     )
   }
 
@@ -49,6 +51,8 @@ object ChanFilterMapper {
         applyToSaved = chanFilter.applyToSaved,
         applyToEmptyComments = chanFilter.applyToEmptyComments,
         filterWatchNotify = chanFilter.filterWatchNotify,
+        filterWatchAutoSave = chanFilter.filterWatchAutoSave,
+        filterWatchAutoSaveMedia = chanFilter.filterWatchAutoSaveMedia,
       ),
       chanFilterBoardConstraintEntityList = chanFilter.boards.map { boardDescriptor ->
         ChanFilterBoardConstraintEntity(

--- a/Kuroba/core-model/src/main/java/com/github/k1rakishou/model/migrations/Migration_v41_to_v42.kt
+++ b/Kuroba/core-model/src/main/java/com/github/k1rakishou/model/migrations/Migration_v41_to_v42.kt
@@ -1,0 +1,16 @@
+package com.github.k1rakishou.model.migrations
+
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
+import com.github.k1rakishou.model.KurobaDatabase
+
+class Migration_v41_to_v42 : Migration(41, 42) {
+
+  override fun migrate(database: SupportSQLiteDatabase) {
+    database.doWithoutForeignKeys {
+      database.execSQL("ALTER TABLE chan_filter ADD COLUMN filter_watch_autosave INTEGER NOT NULL DEFAULT ${KurobaDatabase.SQLITE_FALSE}");
+      database.execSQL("ALTER TABLE chan_filter ADD COLUMN filter_watch_autosave_media INTEGER NOT NULL DEFAULT ${KurobaDatabase.SQLITE_FALSE}");
+    }
+  }
+
+}


### PR DESCRIPTION
Added feature to avoid tread watching when filter pattern is matched
Respects filter order

Can be used instead of a convoluted regex pattern when multiple threads include the filter text you want to watch for, but you are only interested in one/some of them
