### PR TITLE
Avoid thread watching

### DIFF
--- a/Kuroba/app/src/main/java/com/github/k1rakishou/chan/core/site/loader/internal/usecase/AbstractParsePostsUseCase.kt
+++ b/Kuroba/app/src/main/java/com/github/k1rakishou/chan/core/site/loader/internal/usecase/AbstractParsePostsUseCase.kt
@@ -89,7 +89,7 @@ abstract class AbstractParsePostsUseCase(
     }
 
     for (filter in filters) {
-      if (filter.isWatchFilter()) {
+      if (filter.isWatchFilter() || filter.isAvoidWatchFilter()) {
         // Do not auto create watch filters, this may end up pretty bad
         continue
       }
@@ -136,6 +136,9 @@ abstract class AbstractParsePostsUseCase(
       }
       FilterAction.WATCH -> {
         throw IllegalStateException("Cannot auto-create WATCH filters")
+      }
+      FilterAction.AVOID_WATCH -> {
+        throw IllegalStateException("Cannot auto-create AVOID_WATCH filters")
       }
     }
   }

--- a/Kuroba/app/src/main/java/com/github/k1rakishou/chan/core/usecase/BookmarkFilterWatchableThreadsUseCase.kt
+++ b/Kuroba/app/src/main/java/com/github/k1rakishou/chan/core/usecase/BookmarkFilterWatchableThreadsUseCase.kt
@@ -388,12 +388,20 @@ class BookmarkFilterWatchableThreadsUseCase(
 
       if (filterEngine.typeMatches(watchFilter, FilterType.COMMENT)) {
         if (filterEngine.matches(watchFilter, parsedComment, false)) {
+          if (watchFilter.isAvoidWatchFilter())
+          {
+            return null;
+          }
           return watchFilter
         }
       }
 
       if (filterEngine.typeMatches(watchFilter, FilterType.SUBJECT)) {
         if (filterEngine.matches(watchFilter, subject, false)) {
+          if (watchFilter.isAvoidWatchFilter())
+          {
+            return null;
+          }
           return watchFilter
         }
       }

--- a/Kuroba/app/src/main/java/com/github/k1rakishou/chan/core/usecase/KurobaSettingsImportUseCase.kt
+++ b/Kuroba/app/src/main/java/com/github/k1rakishou/chan/core/usecase/KurobaSettingsImportUseCase.kt
@@ -478,7 +478,7 @@ class KurobaSettingsImportUseCase(
             return@jsonObject
           }
 
-          if (action == FilterAction.WATCH.id || action == FilterAction.AVOID_WATCH.id) {
+          if (action == FilterAction.WATCH.id) {
             Logger.e(TAG, "readFilters() Skipping WATCH filter")
             return@jsonObject
           }

--- a/Kuroba/app/src/main/java/com/github/k1rakishou/chan/core/usecase/KurobaSettingsImportUseCase.kt
+++ b/Kuroba/app/src/main/java/com/github/k1rakishou/chan/core/usecase/KurobaSettingsImportUseCase.kt
@@ -478,7 +478,7 @@ class KurobaSettingsImportUseCase(
             return@jsonObject
           }
 
-          if (action == FilterAction.WATCH.id) {
+          if (action == FilterAction.WATCH.id || action == FilterAction.AVOID_WATCH.id) {
             Logger.e(TAG, "readFilters() Skipping WATCH filter")
             return@jsonObject
           }

--- a/Kuroba/app/src/main/java/com/github/k1rakishou/chan/features/filters/CreateOrUpdateFilterController.kt
+++ b/Kuroba/app/src/main/java/com/github/k1rakishou/chan/features/filters/CreateOrUpdateFilterController.kt
@@ -217,7 +217,7 @@ class CreateOrUpdateFilterController(
     var filterWatchNotify by remember { chanFilterMutableState.filterWatchNotify }
     val arrowDropDownDrawable = remember { getTextDrawableContent() }
 
-    if (action == FilterAction.WATCH.id) {
+    if (action == FilterAction.WATCH.id || action == FilterAction.AVOID_WATCH.id  ) {
       applyToReplies = false
       applyToSaved = false
       applyToEmptyComments = false
@@ -385,7 +385,7 @@ class CreateOrUpdateFilterController(
         .fillMaxWidth()
         .wrapContentHeight(),
       text = stringResource(id = R.string.filter_only_on_op),
-      enabled = action != FilterAction.WATCH.id,
+      enabled = action != FilterAction.WATCH.id && action != FilterAction.AVOID_WATCH.id,
       currentlyChecked = onlyOnOP,
       onCheckChanged = { checked -> onlyOnOP = checked }
     )
@@ -402,7 +402,7 @@ class CreateOrUpdateFilterController(
       )
     }
 
-    if (action != FilterAction.WATCH.id) {
+    if (action != FilterAction.WATCH.id && action != FilterAction.AVOID_WATCH.id) {
       KurobaComposeCheckbox(
         modifier = Modifier
           .fillMaxWidth()

--- a/Kuroba/app/src/main/res/values/strings.xml
+++ b/Kuroba/app/src/main/res/values/strings.xml
@@ -396,7 +396,10 @@ Usually that means that you forgot to remove a space from the beginning or the e
             <b>Remove:</b> Remove this post. It won\'t be visible at all.<br>
             <b>Watch:</b> If you have the filter watcher enabled, catalogs will be periodically checked
             based on your interval setting and any OP that matches the filter will be put into your bookmarks.
-            Any catalogs loaded by the you navigating to them from the board select popup will also be checked.<br><br>
+            Any catalogs loaded by the you navigating to them from the board select popup will also be checked.<br>
+            <b>Avoid watch:</b> Works together with watch filters, the same interval settings apply. Allows exceptions
+            in bookmark creation. Explicitly skips watching any matching OP that would otherwise be bookmarked by watch filters later in the filter order.
+            <br><br>
             Enabled filters have priority from top to bottom. Filter precedence for actions is as follows:<br>
             1) Capcode or sticky<br>
             2) OP<br>

--- a/Kuroba/core-model/src/main/java/com/github/k1rakishou/model/data/filter/ChanFilter.kt
+++ b/Kuroba/core-model/src/main/java/com/github/k1rakishou/model/data/filter/ChanFilter.kt
@@ -38,7 +38,7 @@ class ChanFilter(
   }
 
   fun isEnabledWatchFilter(): Boolean {
-    return enabled && isWatchFilter()
+    return enabled && (isWatchFilter() || isAvoidWatchFilter())
   }
 
   fun isEnabledHighlightFilter(): Boolean {
@@ -47,6 +47,10 @@ class ChanFilter(
 
   fun isWatchFilter(): Boolean {
     return action == FilterAction.WATCH.id
+  }
+
+  fun isAvoidWatchFilter(): Boolean {
+    return action == FilterAction.AVOID_WATCH.id
   }
 
   fun isHighlightFilter(): Boolean {

--- a/Kuroba/core-model/src/main/java/com/github/k1rakishou/model/data/filter/ChanFilterMutable.kt
+++ b/Kuroba/core-model/src/main/java/com/github/k1rakishou/model/data/filter/ChanFilterMutable.kt
@@ -26,7 +26,7 @@ class ChanFilterMutable(
   fun allBoards(): Boolean = allBoardsSelected && boards.isEmpty()
 
   fun isWatchFilter(): Boolean {
-    return action == FilterAction.WATCH.id
+    return action == FilterAction.WATCH.id || action == FilterAction.AVOID_WATCH.id
   }
 
   fun applyToBoards(allBoardsChecked: Boolean, boards: List<ChanBoard>) {

--- a/Kuroba/core-model/src/main/java/com/github/k1rakishou/model/data/filter/FilterAction.java
+++ b/Kuroba/core-model/src/main/java/com/github/k1rakishou/model/data/filter/FilterAction.java
@@ -4,7 +4,8 @@ public enum FilterAction {
     HIDE(0),
     COLOR(1),
     REMOVE(2),
-    WATCH(3);
+    WATCH(3),
+    AVOID_WATCH(4);
 
     public final int id;
 
@@ -16,7 +17,7 @@ public enum FilterAction {
         return enums[id];
     }
 
-    private static FilterAction[] enums = new FilterAction[4];
+    private static FilterAction[] enums = new FilterAction[FilterAction.values().length];
 
     public static String filterActionName(FilterAction action) {
         switch (action) {
@@ -28,6 +29,8 @@ public enum FilterAction {
                 return "Remove post";
             case WATCH:
                 return "Watch post";
+            case AVOID_WATCH:
+                return "Avoid watching post";
         }
 
         return "Unknown action (" + action.id + ")";


### PR DESCRIPTION
Added feature to avoid tread watching when filter pattern is matched
Respects filter order

Can be used instead of a convoluted regex pattern when multiple threads include the filter text you want to watch for, but you are only interested in one/some of them
