### PR TITLE
fix(SuspendableInitializer): use waiters monitor in runWhenInitialized to prevent ANR (#1046)

### DIFF
--- a/Kuroba/app/src/main/java/com/github/k1rakishou/chan/core/site/SiteResolver.kt
+++ b/Kuroba/app/src/main/java/com/github/k1rakishou/chan/core/site/SiteResolver.kt
@@ -40,6 +40,19 @@ open class SiteResolver @Inject constructor(
       httpUrl = httpUrl.newBuilder().scheme("https").build()
     }
 
+    // Background callers like the OkHttp interceptors and the bookmark watcher
+    // may invoke this method on a worker thread before SiteManager has finished
+    // its async initialization. firstActiveSiteOrNull() would then throw
+    // IllegalStateException("SiteManager is not ready yet!"), which propagates
+    // out of the OkHttp call and surfaces as an ANR or a hard crash on app
+    // start (see issue #1046). Treat "not ready yet" the same as "no matching
+    // site": the caller already handles a null result and the next request
+    // after init completes will resolve normally.
+    if (!siteManager.isReady()) {
+      Logger.warning(TAG) { "findSiteForUrl('${url}') -> null (SiteManager is not ready yet)" }
+      return null
+    }
+
     return siteManager.firstActiveSiteOrNull { _, site ->
       val siteUrlHandler = site.urlHandler
       if (siteUrlHandler.respondsTo(httpUrl)) {

--- a/Kuroba/app/src/main/java/com/github/k1rakishou/chan/core/site/SiteResolver.kt
+++ b/Kuroba/app/src/main/java/com/github/k1rakishou/chan/core/site/SiteResolver.kt
@@ -6,11 +6,13 @@ import com.github.k1rakishou.model.data.descriptor.ChanDescriptor
 import okhttp3.HttpUrl
 import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import java.util.concurrent.CountDownLatch
+import java.util.concurrent.atomic.AtomicBoolean
 import javax.inject.Inject
 
 open class SiteResolver @Inject constructor(
   private val siteManager: SiteManager
 ) {
+  private val notReadyDiagnosticLogged = AtomicBoolean(false)
 
   fun waitUntilInitialized() {
     if (siteManager.isReady()) {
@@ -40,16 +42,28 @@ open class SiteResolver @Inject constructor(
       httpUrl = httpUrl.newBuilder().scheme("https").build()
     }
 
-    // Background callers like the OkHttp interceptors and the bookmark watcher
-    // may invoke this method on a worker thread before SiteManager has finished
-    // its async initialization. firstActiveSiteOrNull() would then throw
-    // IllegalStateException("SiteManager is not ready yet!"), which propagates
-    // out of the OkHttp call and surfaces as an ANR or a hard crash on app
-    // start (see issue #1046). Treat "not ready yet" the same as "no matching
-    // site": the caller already handles a null result and the next request
-    // after init completes will resolve normally.
+    // Background callers can race SiteManager initialization (issue #1046).
+    // Returning null here keeps the app alive while we collect the diagnostic
+    // information requested in PR review. The first time the guard fires per
+    // process we dump the calling thread name and the captured stack so the
+    // next crash report identifies the actual caller. CloudFlareInterceptor
+    // already calls waitUntilInitialized() above every findSiteForUrl, so the
+    // offender lives somewhere else.
     if (!siteManager.isReady()) {
-      Logger.warning(TAG) { "findSiteForUrl('${url}') -> null (SiteManager is not ready yet)" }
+      if (notReadyDiagnosticLogged.compareAndSet(false, true)) {
+        val callerThread = Thread.currentThread().name
+        val callerStack = Throwable("findSiteForUrl called before SiteManager was ready")
+          .stackTraceToString()
+        Logger.error(TAG) {
+          "findSiteForUrl('${url}') -> null (SiteManager is not ready yet, " +
+            "thread=${callerThread}). Captured caller stack:\n${callerStack}"
+        }
+      } else {
+        Logger.warning(TAG) {
+          "findSiteForUrl('${url}') -> null (SiteManager is not ready yet, " +
+            "thread=${Thread.currentThread().name})"
+        }
+      }
       return null
     }
 

--- a/Kuroba/app/src/main/java/com/github/k1rakishou/chan/core/site/SiteResolver.kt
+++ b/Kuroba/app/src/main/java/com/github/k1rakishou/chan/core/site/SiteResolver.kt
@@ -6,13 +6,11 @@ import com.github.k1rakishou.model.data.descriptor.ChanDescriptor
 import okhttp3.HttpUrl
 import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import java.util.concurrent.CountDownLatch
-import java.util.concurrent.atomic.AtomicBoolean
 import javax.inject.Inject
 
 open class SiteResolver @Inject constructor(
   private val siteManager: SiteManager
 ) {
-  private val notReadyDiagnosticLogged = AtomicBoolean(false)
 
   fun waitUntilInitialized() {
     if (siteManager.isReady()) {
@@ -40,31 +38,6 @@ open class SiteResolver @Inject constructor(
 
     if (httpUrl.scheme != "https") {
       httpUrl = httpUrl.newBuilder().scheme("https").build()
-    }
-
-    // Background callers can race SiteManager initialization (issue #1046).
-    // Returning null here keeps the app alive while we collect the diagnostic
-    // information requested in PR review. The first time the guard fires per
-    // process we dump the calling thread name and the captured stack so the
-    // next crash report identifies the actual caller. CloudFlareInterceptor
-    // already calls waitUntilInitialized() above every findSiteForUrl, so the
-    // offender lives somewhere else.
-    if (!siteManager.isReady()) {
-      if (notReadyDiagnosticLogged.compareAndSet(false, true)) {
-        val callerThread = Thread.currentThread().name
-        val callerStack = Throwable("findSiteForUrl called before SiteManager was ready")
-          .stackTraceToString()
-        Logger.error(TAG) {
-          "findSiteForUrl('${url}') -> null (SiteManager is not ready yet, " +
-            "thread=${callerThread}). Captured caller stack:\n${callerStack}"
-        }
-      } else {
-        Logger.warning(TAG) {
-          "findSiteForUrl('${url}') -> null (SiteManager is not ready yet, " +
-            "thread=${Thread.currentThread().name})"
-        }
-      }
-      return null
     }
 
     return siteManager.firstActiveSiteOrNull { _, site ->

--- a/Kuroba/core-common/src/main/java/com/github/k1rakishou/common/SuspendableInitializer.kt
+++ b/Kuroba/core-common/src/main/java/com/github/k1rakishou/common/SuspendableInitializer.kt
@@ -126,22 +126,17 @@ class SuspendableInitializer<T> @JvmOverloads constructor(
   }
 
   fun runWhenInitialized(func: (Throwable?) -> Unit) {
-    // The waiters list is @GuardedBy("itself") and notifyAllWaiters takes
-    // synchronized(waiters). The previous implementation acquired
-    // synchronized(this), which is a different monitor. That allowed a
-    // waiter added concurrently with init completion to land in the list
-    // AFTER notifyAllWaiters had already drained it, leaving the waiter
-    // never invoked and any caller blocked on a CountDownLatch forever
-    // (the ANR pattern reported in issue #1046). Use the same monitor for
-    // both add and drain, and re-check completion inside the lock.
     synchronized(waiters) {
+      // If not completed then add a new waiter into the list of waiters
       if (!value.isCompleted) {
         waiters += func
         return
       }
     }
 
+    // If already completed then invoke the current waiter + other waiters if there are any
     func(error.get())
+    notifyAllWaiters(error.get())
   }
 
   private fun notifyAllWaiters(throwable: Throwable? = null) {

--- a/Kuroba/core-common/src/main/java/com/github/k1rakishou/common/SuspendableInitializer.kt
+++ b/Kuroba/core-common/src/main/java/com/github/k1rakishou/common/SuspendableInitializer.kt
@@ -126,15 +126,22 @@ class SuspendableInitializer<T> @JvmOverloads constructor(
   }
 
   fun runWhenInitialized(func: (Throwable?) -> Unit) {
-    if (isInitialized()) {
-      func(null)
-      notifyAllWaiters(null)
-      return
+    // The waiters list is @GuardedBy("itself") and notifyAllWaiters takes
+    // synchronized(waiters). The previous implementation acquired
+    // synchronized(this), which is a different monitor. That allowed a
+    // waiter added concurrently with init completion to land in the list
+    // AFTER notifyAllWaiters had already drained it, leaving the waiter
+    // never invoked and any caller blocked on a CountDownLatch forever
+    // (the ANR pattern reported in issue #1046). Use the same monitor for
+    // both add and drain, and re-check completion inside the lock.
+    synchronized(waiters) {
+      if (!value.isCompleted) {
+        waiters += func
+        return
+      }
     }
 
-    synchronized(this) {
-      waiters += func
-    }
+    func(error.get())
   }
 
   private fun notifyAllWaiters(throwable: Throwable? = null) {


### PR DESCRIPTION
## Fix SuspendableInitializer.runWhenInitialized lock mismatch (refs #1046)

Resolves #1046

`SuspendableInitializer.waiters` is annotated `@GuardedBy("itself")` and `notifyAllWaiters` correctly uses `synchronized(waiters) { ... }`. But `runWhenInitialized` was using `synchronized(this) { waiters += func }`. Two different monitors. The interleaving below loses a waiter:

```
Thread A (caller of runWhenInitialized):
  isInitialized() returns false
  ...

Thread B (init completes):
  value.complete(...)
  notifyAllWaiters() -> synchronized(waiters) { copy = []; clear }
  invokes nothing because the list is empty

Thread A (resumes):
  synchronized(this) { waiters += func }
  func is now in waiters and will never be invoked
```

`SiteResolver.waitUntilInitialized()` blocks on a `CountDownLatch` that the lost waiter was supposed to count down, so the caller waits forever. If that thread is the OkHttp dispatcher used for an interceptor the user sees an ANR. If a different thread later reaches `firstActiveSiteOrNull`, it throws `IllegalStateException("SiteManager is not ready yet!")`, which matches the report in #1046.

### Fix

Use one monitor for both add and drain, and re-check completion under the lock:

```kotlin
fun runWhenInitialized(func: (Throwable?) -> Unit) {
  synchronized(waiters) {
    if (!value.isCompleted) {
      waiters += func
      return
    }
  }

  func(error.get())
}
```

### Files changed

- `Kuroba/core-common/src/main/java/com/github/k1rakishou/common/SuspendableInitializer.kt`
