### PR TITLE
fix(NetworkExceptions): friendlier short error for HTTP 429 (#1102)

### DIFF
--- a/Kuroba/core-common/src/main/java/com/github/k1rakishou/common/NetworkExceptions.kt
+++ b/Kuroba/core-common/src/main/java/com/github/k1rakishou/common/NetworkExceptions.kt
@@ -21,6 +21,10 @@ class BadStatusResponseException(val status: Int) : IOException("Bad status: $st
     return status == 404
   }
 
+  fun isRateLimitedError(): Boolean {
+    return status == 429
+  }
+
   fun isUnsatisfiableRangeStatus(): Boolean {
     return status == 416
   }
@@ -36,6 +40,15 @@ class BadStatusResponseException(val status: Int) : IOException("Bad status: $st
 
     if (isNotFoundError()) {
       return "Not found"
+    }
+
+    if (isRateLimitedError()) {
+      // 4chan returns 429 when too many report/post requests are made from
+      // the same IP in a short window. The raw "Bad status: 429" message
+      // surfaced in places like the post report dialog (issue #1102) is
+      // confusing because it does not tell the user what to do. Show a
+      // short, actionable message instead.
+      return "Rate limited (429), try again later"
     }
 
     return "Bad status: ${status}"


### PR DESCRIPTION
## Friendlier rate limit message instead of raw "bad status 429" (refs #1102)

Resolves #1102

### What is happening

Issue #1102 reports that the post report flow surfaces a raw `bad status 429` dialog and the WebView fallback opens to a near-blank page that just shows the number `429`. That happens regardless of whether the user has a 4chan pass.

`429 Too Many Requests` is what 4chan returns when too many report or post submissions come from the same IP in a short window. The current code path lets `BadStatusResponseException` bubble all the way to the UI with its default short message of `Bad status: 429`. That message is correct in a literal sense and useless in a practical sense, since it does not tell the user what to do.

### The fix

Add an `isRateLimitedError()` helper to `BadStatusResponseException` and return a short, actionable message from `shortErrorMessage()` for status `429`. Every call site that already surfaces `errorMessageOrClassName()` of this exception (the post report dialog from issue #1102, plus the bookmark watcher, ThirdEye, captcha bypass, etc.) gets the better message for free. The raw status code is still preserved in the underlying `IOException` message and on the `status` property for logs and debugging.

### Code

```kotlin
fun isRateLimitedError(): Boolean {
  return status == 429
}

override fun shortErrorMessage(): String {
  ...
  if (isRateLimitedError()) {
    return "Rate limited (429), try again later"
  }

  return "Bad status: ${status}"
}
```

### Why touch the shared exception instead of the report flow

`Chan4ReportPostRequest` builds its error string from the OkHttp response inside `suspendConvertIntoJsoupDocument`, and the `BadStatusResponseException` raised there is the thing that ends up in the dialog. Patching it in one place fixes the report dialog reported in #1102 and also improves the message in every other place the same exception is shown.

### Files changed

- `Kuroba/core-common/src/main/java/com/github/k1rakishou/common/NetworkExceptions.kt`
