### PR TITLE
fix(#932): warn before opening a WebView when a site proxy is configured

### DIFF
--- a/Kuroba/app/src/main/java/com/github/k1rakishou/chan/ui/controller/OpenUrlInWebViewController.kt
+++ b/Kuroba/app/src/main/java/com/github/k1rakishou/chan/ui/controller/OpenUrlInWebViewController.kt
@@ -11,8 +11,10 @@ import android.widget.FrameLayout
 import android.widget.ImageView
 import com.github.k1rakishou.chan.R
 import com.github.k1rakishou.chan.core.di.component.activity.ActivityComponent
+import com.github.k1rakishou.chan.core.helper.ProxyStorage
 import com.github.k1rakishou.chan.core.site.SiteResolver
 import com.github.k1rakishou.chan.ui.controller.base.BaseFloatingController
+import com.github.k1rakishou.chan.utils.AppModuleAndroidUtils.getString
 import com.github.k1rakishou.common.AppConstants
 import com.github.k1rakishou.common.CookieBuilder
 import com.github.k1rakishou.common.resumeValueSafe
@@ -21,6 +23,7 @@ import com.github.k1rakishou.core_themes.ThemeEngine
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.suspendCancellableCoroutine
 import okhttp3.HttpUrl
+import java.net.URI
 import javax.inject.Inject
 
 class OpenUrlInWebViewController(
@@ -36,6 +39,9 @@ class OpenUrlInWebViewController(
 
   @Inject
   lateinit var themeEngine: ThemeEngine
+
+  @Inject
+  lateinit var proxyStorage: ProxyStorage
 
   private lateinit var webView: WebView
   private lateinit var closeButton: ImageView
@@ -87,6 +93,49 @@ class OpenUrlInWebViewController(
 
   @SuppressLint("SetJavaScriptEnabled")
   private suspend fun onCreateInternal() {
+    // Issue #932: the Android WebView does not honor the proxies that
+    // Kuroba routes its OkHttp traffic through. If a proxy is configured
+    // for the site we are about to open, loading the URL in the WebView
+    // would bypass that proxy and reveal the device IP. Warn the user
+    // and let them choose to open it anyway or cancel.
+    val proxiesForUrl = try {
+      proxyStorage.getProxyByUri(URI(urlToOpen.toString()), ProxyStorage.ProxyActionType.SiteRequests)
+    } catch (_: Throwable) {
+      emptyList()
+    }
+    if (proxiesForUrl.isNotEmpty()) {
+      Logger.warning(TAG) {
+        "WebView for ${urlToOpen} would bypass the proxy configured for this site (issue #932)"
+      }
+      val openAnyway = suspendCancellableCoroutine<Boolean> { cont ->
+        var resumed = false
+        fun resumeOnce(value: Boolean) {
+          if (resumed) {
+            return
+          }
+          resumed = true
+          cont.resumeValueSafe(value)
+        }
+        val handle = dialogFactory.createSimpleConfirmationDialog(
+          context = context,
+          titleTextId = R.string.open_url_in_webview_proxy_leak_title,
+          descriptionTextId = R.string.open_url_in_webview_proxy_leak_description,
+          positiveButtonText = getString(R.string.open_url_in_webview_proxy_leak_open_anyway),
+          negativeButtonText = getString(R.string.cancel),
+          onPositiveButtonClickListener = { resumeOnce(true) },
+          onNegativeButtonClickListener = { resumeOnce(false) },
+          onDismissListener = { resumeOnce(false) }
+        )
+        if (handle == null) {
+          resumeOnce(false)
+        }
+      }
+      if (!openAnyway) {
+        pop()
+        return
+      }
+    }
+
     val webViewContainer = view.findViewById<FrameLayout>(R.id.web_view_container)
 
     themeEngine.addListener(this)

--- a/Kuroba/app/src/main/java/com/github/k1rakishou/chan/ui/controller/OpenUrlInWebViewController.kt
+++ b/Kuroba/app/src/main/java/com/github/k1rakishou/chan/ui/controller/OpenUrlInWebViewController.kt
@@ -14,7 +14,7 @@ import com.github.k1rakishou.chan.core.di.component.activity.ActivityComponent
 import com.github.k1rakishou.chan.core.helper.ProxyStorage
 import com.github.k1rakishou.chan.core.site.SiteResolver
 import com.github.k1rakishou.chan.ui.controller.base.BaseFloatingController
-import com.github.k1rakishou.chan.utils.AppModuleAndroidUtils.getString
+import com.github.k1rakishou.chan.ui.controller.dialog.KurobaComposeDialogController
 import com.github.k1rakishou.common.AppConstants
 import com.github.k1rakishou.common.CookieBuilder
 import com.github.k1rakishou.common.resumeValueSafe
@@ -107,29 +107,31 @@ class OpenUrlInWebViewController(
       Logger.warning(TAG) {
         "WebView for ${urlToOpen} would bypass the proxy configured for this site (issue #932)"
       }
-      val openAnyway = suspendCancellableCoroutine<Boolean> { cont ->
-        var resumed = false
-        fun resumeOnce(value: Boolean) {
-          if (resumed) {
-            return
-          }
-          resumed = true
-          cont.resumeValueSafe(value)
-        }
-        val handle = dialogFactory.createSimpleConfirmationDialog(
-          context = context,
-          titleTextId = R.string.open_url_in_webview_proxy_leak_title,
-          descriptionTextId = R.string.open_url_in_webview_proxy_leak_description,
-          positiveButtonText = getString(R.string.open_url_in_webview_proxy_leak_open_anyway),
-          negativeButtonText = getString(R.string.cancel),
-          onPositiveButtonClickListener = { resumeOnce(true) },
-          onNegativeButtonClickListener = { resumeOnce(false) },
-          onDismissListener = { resumeOnce(false) }
+      val params = KurobaComposeDialogController.confirmationDialog(
+        title = KurobaComposeDialogController.Text.Id(
+          R.string.open_url_in_webview_proxy_leak_title
+        ),
+        description = KurobaComposeDialogController.Text.Id(
+          R.string.open_url_in_webview_proxy_leak_description
+        ),
+        negativeButton = KurobaComposeDialogController.DialogButton(R.string.cancel),
+        positionButton = KurobaComposeDialogController.PositiveDialogButton(
+          buttonText = R.string.open_url_in_webview_proxy_leak_open_anyway,
+          isActionDangerous = true
         )
-        if (handle == null) {
-          resumeOnce(false)
-        }
+      )
+
+      val handle = dialogFactory.showDialog(
+        context = context,
+        params = params
+      )
+
+      if (handle == null) {
+        pop()
+        return
       }
+
+      val openAnyway = params.awaitButtonClick()?.isPositive() == true
       if (!openAnyway) {
         pop()
         return

--- a/Kuroba/app/src/main/res/values/strings.xml
+++ b/Kuroba/app/src/main/res/values/strings.xml
@@ -1708,4 +1708,8 @@ Actual error: \'%1$s\'</string>
     <string name="api_33_android_13_notifications_permission_title">Api 33 (Android 13+) notifications permission</string>
     <string name="api_33_android_13_notifications_permission_descriptor">Api 33 (Android 13+) requires applications to request for a permission to display notifications. Without this permission some application features may not work correctly (posting, media downloading, reply notifications, thread last page notifications, etc).\n\nYou can always enable this manually in Android OS application settings.</string>
 
+    <string name="open_url_in_webview_proxy_leak_title">Open in WebView would bypass the proxy</string>
+    <string name="open_url_in_webview_proxy_leak_description">A proxy is configured for this site, but the Android WebView does not honor application proxies. Loading this URL in the built in WebView will connect directly and may reveal your real IP to the destination.\n\nOpen anyway, or cancel and use an external app.</string>
+    <string name="open_url_in_webview_proxy_leak_open_anyway">Open anyway</string>
+
 </resources>


### PR DESCRIPTION
## Warn before opening a WebView when a proxy is configured (refs #932)

Resolves #932

### Background

The Android `WebView` does not honor the proxies that Kuroba routes its OkHttp traffic through. If a user configures a proxy for a site to hide their IP, then taps a link that opens in the in app WebView, the WebView connects directly and the destination sees the real IP.

### What this PR does

When `OpenUrlInWebViewController` is about to load a URL, it checks `ProxyStorage.getProxyByUri(...)` for a proxy configured for that site. If a proxy is configured, it shows a confirmation dialog before loading. The user can choose to open anyway or cancel.

### Implementation notes

- Uses `dialogFactory.showDialog` with `KurobaComposeDialogController.confirmationDialog`. The positive button is marked `isActionDangerous` because opening anyway is the risky action.
- If `showDialog` returns null (app not in foreground), we just pop the controller. No leak.
- Awaits the button click via `params.awaitButtonClick()`, so no manual `suspendCancellableCoroutine` glue.

### Strings added

```
open_url_in_webview_proxy_leak_title
open_url_in_webview_proxy_leak_description
open_url_in_webview_proxy_leak_open_anyway
```

### Files changed

- `Kuroba/app/src/main/java/com/github/k1rakishou/chan/ui/controller/OpenUrlInWebViewController.kt`
- `Kuroba/app/src/main/res/values/strings.xml`
