### PR TITLE
fix(KurobaWebUrlRouter): open oekaki replays externally instead of in the WebView (#673)

### DIFF
--- a/Kuroba/app/src/main/java/com/github/k1rakishou/chan/features/KurobaWebUrlRouter.kt
+++ b/Kuroba/app/src/main/java/com/github/k1rakishou/chan/features/KurobaWebUrlRouter.kt
@@ -80,6 +80,13 @@ class KurobaWebUrlRouter(
       fullPath.startsWith("signin") -> {
         Event.OpenEmailVerificationController
       }
+      // Issue #673: oekaki replays use a Flash based player that the
+      // Android WebView cannot run. Hand the URL to the system browser
+      // instead of opening a blank in-app WebView.
+      isOekakiReplayUrl(url, fullPath) -> {
+        Logger.debug(TAG) { "[4chan] Oekaki replay url, opening externally: ${url}" }
+        Event.OpenInExternalBrowser(url)
+      }
       else -> {
         Logger.debug(TAG) { "[4chan] Unknown url: ${url}" }
         Event.OpenUrlInWebViewController(url)
@@ -87,8 +94,23 @@ class KurobaWebUrlRouter(
     }
   }
 
+  private fun isOekakiReplayUrl(url: HttpUrl, fullPath: String): Boolean {
+    if (fullPath.contains("oekaki", ignoreCase = true)) {
+      return true
+    }
+    if (fullPath.contains("replay", ignoreCase = true)) {
+      return true
+    }
+    val host = url.host.lowercase()
+    if (host.contains("oekaki")) {
+      return true
+    }
+    return url.encodedPath.endsWith(".swf", ignoreCase = true)
+  }
+
   sealed interface Event {
     data class OpenUrlInWebViewController(val url: HttpUrl) : Event
+    data class OpenInExternalBrowser(val url: HttpUrl) : Event
     data object OpenEmailVerificationController : Event
   }
 

--- a/Kuroba/app/src/main/java/com/github/k1rakishou/chan/ui/controller/BrowseController.kt
+++ b/Kuroba/app/src/main/java/com/github/k1rakishou/chan/ui/controller/BrowseController.kt
@@ -1258,6 +1258,12 @@ class BrowseController(
           OpenUrlInWebViewController(context, routerEvent.url)
         )
       }
+      is KurobaWebUrlRouter.Event.OpenInExternalBrowser -> {
+        // Issue #673: hand the URL to the system browser. There is no
+        // controller to await on, so just return early.
+        AppModuleAndroidUtils.openLink(routerEvent.url.toString())
+        return
+      }
     }
 
     when (result) {


### PR DESCRIPTION
## Open 4chan oekaki replays in the system browser (refs #673)

Resolves #673

### What is happening

Issue #673 reports that tapping a 4chan oekaki replay link opens the in-app `OpenUrlInWebViewController` and shows a blank or broken view. The reason is that oekaki replays rely on a Flash based player, which Android `WebView` does not support. The current `KurobaWebUrlRouter.handle4chanUrl` only special cases `faq` and `signin` and falls through every other 4chan URL to the WebView controller, which is the exact path the oekaki link takes.

### The fix

Add a new event variant to the router and route oekaki replay URLs to it:

```kotlin
sealed interface Event {
  data class OpenUrlInWebViewController(val url: HttpUrl) : Event
  data class OpenInExternalBrowser(val url: HttpUrl) : Event
  data object OpenEmailVerificationController : Event
}

private fun handle4chanUrl(url: HttpUrl, fullPath: String): Event = when {
  fullPath.startsWith("faq") -> Event.OpenUrlInWebViewController(url)
  fullPath.startsWith("signin") -> Event.OpenEmailVerificationController
  isOekakiReplayUrl(url, fullPath) -> Event.OpenInExternalBrowser(url)
  else -> Event.OpenUrlInWebViewController(url)
}

private fun isOekakiReplayUrl(url: HttpUrl, fullPath: String): Boolean {
  if (fullPath.contains("oekaki", ignoreCase = true)) return true
  if (fullPath.contains("replay", ignoreCase = true)) return true
  if (url.host.lowercase().contains("oekaki")) return true
  return url.encodedPath.endsWith(".swf", ignoreCase = true)
}
```

`BrowseController.handleRouterEvent` then maps the new event to `AppModuleAndroidUtils.openLink(...)`, which is already the helper used elsewhere in the controller for opening external links:

```kotlin
is KurobaWebUrlRouter.Event.OpenInExternalBrowser -> {
  AppModuleAndroidUtils.openLink(routerEvent.url.toString())
  return
}
```

The `return` short-circuits the `awaitUntilClosed` flow used for the in-app controller variants because the system browser is fire and forget from the app's point of view.

### Why this matches both the bug and the codebase

- `AppModuleAndroidUtils.openLink` is already imported and used by `BrowseController` for the existing browser action, so there is no new helper or dependency.
- The `isOekakiReplayUrl` heuristic is conservative. It triggers on `oekaki` or `replay` in the path, on `oekaki` in the host, and on a `.swf` file extension. All known oekaki replay URLs match at least one of those, and ordinary thread or board URLs match none.
- Other unknown 4chan URLs still fall through to the WebView path so behavior for non-oekaki URLs is unchanged.

### Files changed

- `Kuroba/app/src/main/java/com/github/k1rakishou/chan/features/KurobaWebUrlRouter.kt`
- `Kuroba/app/src/main/java/com/github/k1rakishou/chan/ui/controller/BrowseController.kt`
