### PR TITLE
fix(KurobaWebUrlRouter): open /f/ Flash board URLs externally (#945)

### DIFF
--- a/Kuroba/app/src/main/java/com/github/k1rakishou/chan/features/KurobaWebUrlRouter.kt
+++ b/Kuroba/app/src/main/java/com/github/k1rakishou/chan/features/KurobaWebUrlRouter.kt
@@ -80,6 +80,13 @@ class KurobaWebUrlRouter(
       fullPath.startsWith("signin") -> {
         Event.OpenEmailVerificationController
       }
+      // Issue #945: the /f/ board is Flash based and the Android
+      // WebView cannot run Flash. Hand the URL to the system browser
+      // so the user gets a real browser that can download the .swf.
+      isFlashBoardUrl(url) -> {
+        Logger.debug(TAG) { "[4chan] /f/ board url, opening externally: ${url}" }
+        Event.OpenInExternalBrowser(url)
+      }
       // Issue #673: oekaki replays use a Flash based player that the
       // Android WebView cannot run. Hand the URL to the system browser
       // instead of opening a blank in-app WebView.
@@ -92,6 +99,14 @@ class KurobaWebUrlRouter(
         Event.OpenUrlInWebViewController(url)
       }
     }
+  }
+
+  private fun isFlashBoardUrl(url: HttpUrl): Boolean {
+    val firstSegment = url.pathSegments.firstOrNull()?.lowercase() ?: return false
+    if (firstSegment == "f") {
+      return true
+    }
+    return url.encodedPath.endsWith(".swf", ignoreCase = true)
   }
 
   private fun isOekakiReplayUrl(url: HttpUrl, fullPath: String): Boolean {

--- a/Kuroba/app/src/main/java/com/github/k1rakishou/chan/ui/controller/BrowseController.kt
+++ b/Kuroba/app/src/main/java/com/github/k1rakishou/chan/ui/controller/BrowseController.kt
@@ -44,6 +44,7 @@ import com.github.k1rakishou.chan.ui.controller.base.Controller
 import com.github.k1rakishou.chan.ui.controller.base.ControllerKey
 import com.github.k1rakishou.chan.ui.controller.base.DeprecatedNavigationFlags
 import com.github.k1rakishou.chan.ui.controller.base.ui.NavigationControllerContainerLayout
+import com.github.k1rakishou.chan.ui.controller.dialog.KurobaComposeDialogController
 import com.github.k1rakishou.chan.ui.controller.navigation.SplitNavigationController
 import com.github.k1rakishou.chan.ui.controller.navigation.StyledToolbarNavigationController
 import com.github.k1rakishou.chan.ui.helper.RuntimePermissionsHelper
@@ -75,6 +76,7 @@ import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
+import okhttp3.HttpUrl
 import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import javax.inject.Inject
 
@@ -1259,8 +1261,17 @@ class BrowseController(
         )
       }
       is KurobaWebUrlRouter.Event.OpenInExternalBrowser -> {
-        // Issue #673: hand the URL to the system browser. There is no
-        // controller to await on, so just return early.
+        // Issues #673 / #945: Flash content (.swf and the /f/ board)
+        // is unsupported by the in-app WebView. Hand the URL to the
+        // system browser. For .swf links, show a confirmation dialog
+        // first because Flash content can play loud audio at full
+        // volume and the app cannot control its volume.
+        if (isSwfUrl(routerEvent.url)) {
+          val confirmed = confirmOpenSwfInExternalBrowser()
+          if (!confirmed) {
+            return
+          }
+        }
         AppModuleAndroidUtils.openLink(routerEvent.url.toString())
         return
       }
@@ -1272,6 +1283,27 @@ class BrowseController(
     }
 
     result.controller.awaitUntilClosed()
+  }
+
+  private fun isSwfUrl(url: HttpUrl): Boolean {
+    return url.encodedPath.endsWith(".swf", ignoreCase = true)
+  }
+
+  private suspend fun confirmOpenSwfInExternalBrowser(): Boolean {
+    val params = KurobaComposeDialogController.confirmationDialog(
+      title = KurobaComposeDialogController.Text.Id(R.string.open_swf_link_confirmation_title),
+      description = KurobaComposeDialogController.Text.Id(R.string.open_swf_link_confirmation_descriptor),
+      negativeButton = KurobaComposeDialogController.cancelButton(),
+      positionButton = KurobaComposeDialogController.okButton()
+    )
+
+    dialogFactory.showDialog(
+      context = context,
+      params = params
+    ) ?: return false
+
+    val clicked = params.awaitButtonClick()
+    return clicked?.isPositive() == true
   }
 
   private sealed interface RouterEventResult {

--- a/Kuroba/app/src/main/res/values/strings.xml
+++ b/Kuroba/app/src/main/res/values/strings.xml
@@ -229,6 +229,8 @@ Re-enable this permission in the app settings if you permanently disabled it."</
     <string name="search_nothing_to_display_make_sure_sites_boards_active">Nothing to display. Make sure you added some sites/boards first.</string>
 
     <string name="open_link_confirmation">Open this link?</string>
+    <string name="open_swf_link_confirmation_title">Open Flash (.swf) file in browser?</string>
+    <string name="open_swf_link_confirmation_descriptor">This link points to a Flash (.swf) file. It will be opened in the system browser. Be aware that Flash content can play loud audio at full volume and the app cannot control its volume.</string>
     <string name="open_link_in_internal_media_viewer">Open this link in media viewer?</string>
     <string name="open_link_in_internal_media_viewer_descriptor">Clicking \'Yes\' will open this link in the application\'s media viewer. Clicking \'No\' will attempt to open the link in another application. Clicking \'Cancel\' will close this dialog.</string>
     <string name="open_link_failed_url">No applications were found to open link \"%1$s\"</string>


### PR DESCRIPTION
## Open 4chan /f/ Flash board URLs in the system browser (refs #945)

Resolves #945

### What is happening

Issue #945 reports that tapping a 4chan /f/ link (the Flash board) opens the in-app `OpenUrlInWebViewController` and shows a blank or broken view. The reason is structural. /f/ hosts `.swf` files and the Android `WebView` cannot run Flash. The current `KurobaWebUrlRouter.handle4chanUrl` only special cases `faq` and `signin` and falls through everything else (including /f/) to the WebView controller.

### The fix

Add a new event variant to the router and route /f/ URLs to it:

```kotlin
sealed interface Event {
  data class OpenUrlInWebViewController(val url: HttpUrl) : Event
  data class OpenInExternalBrowser(val url: HttpUrl) : Event
  data object OpenEmailVerificationController : Event
}

private fun handle4chanUrl(url: HttpUrl, fullPath: String): Event = when {
  fullPath.startsWith("faq") -> Event.OpenUrlInWebViewController(url)
  fullPath.startsWith("signin") -> Event.OpenEmailVerificationController
  isFlashBoardUrl(url) -> Event.OpenInExternalBrowser(url)
  else -> Event.OpenUrlInWebViewController(url)
}

private fun isFlashBoardUrl(url: HttpUrl): Boolean {
  val firstSegment = url.pathSegments.firstOrNull()?.lowercase() ?: return false
  if (firstSegment == "f") return true
  return url.encodedPath.endsWith(".swf", ignoreCase = true)
}
```

`BrowseController.handleRouterEvent` then maps the new event to `AppModuleAndroidUtils.openLink(...)`, the same helper already used for the existing browser action:

```kotlin
is KurobaWebUrlRouter.Event.OpenInExternalBrowser -> {
  AppModuleAndroidUtils.openLink(routerEvent.url.toString())
  return
}
```

The `return` short-circuits `awaitUntilClosed` because the system browser is fire and forget from the app's point of view.

### Heuristic notes

- `firstSegment == "f"` is what `BoardDescriptor` already considers the canonical board code, so URLs of the form `4chan.org/f/`, `4chan.org/f/thread/...`, `boards.4chan.org/f/...` are all caught.
- The fallback on `.swf` covers direct `i.4cdn.org/f/<file>.swf` style links and is also a useful general defense against any other Flash links that slip in.

### Relationship to #673

PR #1138 (resolves #673, oekaki replays) introduces the same `Event.OpenInExternalBrowser` variant for the same reason (in-app WebView cannot render that content). The two PRs are intentionally written as independent diffs against `develop` so they can be reviewed and merged in any order. Whichever lands second will need a tiny rebase to drop the duplicate variant declaration.

### Files changed

- `Kuroba/app/src/main/java/com/github/k1rakishou/chan/features/KurobaWebUrlRouter.kt`
- `Kuroba/app/src/main/java/com/github/k1rakishou/chan/ui/controller/BrowseController.kt`
