### PR TITLE
Fix album view 404s for downloaded threads

### DIFF
--- a/Kuroba/app/src/main/java/com/github/k1rakishou/chan/features/album/AlbumItem.kt
+++ b/Kuroba/app/src/main/java/com/github/k1rakishou/chan/features/album/AlbumItem.kt
@@ -353,7 +353,8 @@ private fun getImageLoaderRequestProvider(
         return@withContext ImageLoaderRequest(
           data = ImageLoaderRequestData.Url(
             httpUrl = imageUrl,
-            cacheFileType = cacheFileType
+            cacheFileType = cacheFileType,
+            postDescriptor = albumItemData.postDescriptor
           ),
           transformations = emptyList()
         )

--- a/Kuroba/app/src/main/java/com/github/k1rakishou/chan/ui/compose/image/KurobaComposeImage.kt
+++ b/Kuroba/app/src/main/java/com/github/k1rakishou/chan/ui/compose/image/KurobaComposeImage.kt
@@ -34,6 +34,7 @@ import coil.size.Scale
 import coil.transform.Transformation
 import com.github.k1rakishou.chan.R
 import com.github.k1rakishou.chan.core.cache.CacheFileType
+import com.github.k1rakishou.model.data.descriptor.PostDescriptor
 import com.github.k1rakishou.chan.ui.compose.components.KurobaComposeIcon
 import com.github.k1rakishou.chan.ui.compose.components.KurobaComposeText
 import com.github.k1rakishou.chan.ui.compose.ktu
@@ -242,7 +243,8 @@ sealed class ImageLoaderRequestData {
 
   data class Url(
     val httpUrl: HttpUrl,
-    val cacheFileType: CacheFileType
+    val cacheFileType: CacheFileType,
+    val postDescriptor: PostDescriptor? = null
   ) : ImageLoaderRequestData() {
     val httpUrlString: String = httpUrl.toString()
   }

--- a/Kuroba/app/src/main/java/com/github/k1rakishou/chan/ui/compose/image/KurobaComposePostImageThumbnailShared.kt
+++ b/Kuroba/app/src/main/java/com/github/k1rakishou/chan/ui/compose/image/KurobaComposePostImageThumbnailShared.kt
@@ -185,6 +185,7 @@ private suspend fun ProduceStateScope<ImageLoaderResult>.loadImageInternal(
           cacheFileType = data.cacheFileType,
           imageSize = KurobaImageSize.FixedImageSize(size.width, size.height),
           scale = scale,
+          postDescriptor = data.postDescriptor,
           transformations = request.transformations
         )
       }


### PR DESCRIPTION
When viewing the album for a thread saved via local thread archive (downloader), all album show "HTTP error: 404" because the original thread is dead. The full media viewer and regular post-view thumbnails work fine on the same thread. The album thumbnail loader does not pass `postDescriptor`, so the disk-load step skips the downloaded thread lookup and goes straight to network which 404s on dead threads.

**Changes** - Tested on a downloaded dead thread: album images now load from disk, and the live-thread album still works.
- `ImageLoaderRequestData.Url` gains an optional `postDescriptor` field (defaults to null, non-breaking for existing call sites)
- `KurobaComposePostImageThumbnailShared` forwards it to `kurobaImageLoader.loadFromNetwork`
- `AlbumItem` passes the per-cell `postDescriptor` when building the request



**Issue**:
<img width="1053" height="1979" alt="signal-2026-04-27-220730" src="https://github.com/user-attachments/assets/42028830-82e4-4aeb-8d1c-7efc66e2f56d" />
