### PR TITLE
fix(posting): enable image spoilers on 8chan

### DIFF
--- a/Kuroba/app/src/main/java/com/github/k1rakishou/chan/core/manager/ReplyManager.kt
+++ b/Kuroba/app/src/main/java/com/github/k1rakishou/chan/core/manager/ReplyManager.kt
@@ -318,6 +318,11 @@ class ReplyManager(
     return reader(getReplyOrCreateNew(chanDescriptor))
   }
 
+  suspend fun <T : Any?> readReplySuspending(chanDescriptor: ChanDescriptor, reader: suspend (Reply) -> T): T {
+    ensureFilesLoaded()
+    return reader(getReplyOrCreateNew(chanDescriptor))
+  }
+
   fun createNewEmptyAttachFile(
     uniqueFileName: UniqueFileName,
     originalFileName: String,

--- a/Kuroba/app/src/main/java/com/github/k1rakishou/chan/core/site/sites/lynxchan/engine/LynxchanGetBoardsUseCase.kt
+++ b/Kuroba/app/src/main/java/com/github/k1rakishou/chan/core/site/sites/lynxchan/engine/LynxchanGetBoardsUseCase.kt
@@ -120,6 +120,7 @@ class LynxchanGetBoardsUseCase(
         name = lynxchanBoardsData.boardName,
         description = lynxchanBoardsData.boardDescription ?: "",
         workSafe = workSafe,
+        spoilers = lynxchanBoardsData.supportsImageSpoilers,
         isUnlimitedCatalog = true
       )
     }
@@ -220,6 +221,8 @@ class LynxchanGetBoardsUseCase(
     @field:Json(name = "tags") val tags: List<String>?,
     @field:Json(name = "specialSettings") val specialSettings: List<String>?,
   ) {
+    internal val supportsImageSpoilers: Boolean = true
+
     val hasSfwTag: Boolean
       get() = hasTagOrSpecialSetting(value = "sfw")
 

--- a/Kuroba/app/src/main/java/com/github/k1rakishou/chan/core/site/sites/lynxchan/engine/LynxchanReplyHttpCall.kt
+++ b/Kuroba/app/src/main/java/com/github/k1rakishou/chan/core/site/sites/lynxchan/engine/LynxchanReplyHttpCall.kt
@@ -1,5 +1,6 @@
 package com.github.k1rakishou.chan.core.site.sites.lynxchan.engine
 
+import android.graphics.Bitmap
 import android.text.TextUtils
 import android.util.Base64
 import android.webkit.MimeTypeMap
@@ -11,6 +12,7 @@ import com.github.k1rakishou.chan.features.reply.data.ReplyFile
 import com.github.k1rakishou.chan.features.reply.data.ReplyFileMeta
 import com.github.k1rakishou.chan.ui.captcha.CaptchaSolution
 import com.github.k1rakishou.chan.utils.HashingUtil
+import com.github.k1rakishou.chan.utils.MediaUtils
 import com.github.k1rakishou.common.ModularResult
 import com.github.k1rakishou.common.StringUtils
 import com.github.k1rakishou.common.groupOrNull
@@ -21,6 +23,11 @@ import com.github.k1rakishou.model.data.descriptor.ChanDescriptor
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
 import com.squareup.moshi.Moshi
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.withContext
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.MultipartBody
 import okhttp3.Request
@@ -28,6 +35,8 @@ import okhttp3.RequestBody
 import okhttp3.RequestBody.Companion.asRequestBody
 import okhttp3.Response
 import java.io.IOException
+import java.io.InputStream
+import java.security.MessageDigest
 import java.util.Locale
 import java.util.Objects
 import java.util.regex.Pattern
@@ -60,7 +69,7 @@ class LynxchanReplyHttpCall(
     replyResponse.boardCode = chanDescriptor.boardCode()
     site.requestModifier.modifyHttpCall(this, requestBuilder)
 
-    replyManager.readReply(chanDescriptor) { reply ->
+    replyManager.readReplySuspending(chanDescriptor) { reply ->
       val threadNo = if (chanDescriptor is ChanDescriptor.ThreadDescriptor) {
         chanDescriptor.threadNo
       } else {
@@ -108,7 +117,7 @@ class LynxchanReplyHttpCall(
     }
   }
 
-  private fun postWithFormDataPayload(
+  private suspend fun postWithFormDataPayload(
     reply: Reply,
     chanDescriptor: ChanDescriptor,
     threadNo: Long,
@@ -140,7 +149,10 @@ class LynxchanReplyHttpCall(
     if (reply.hasFiles()) {
       val filesCount = reply.filesCount()
 
-      reply.iterateFilesOrThrowIfEmpty { fileIndex, replyFile ->
+      val replyFiles = mutableListOf<ReplyFile>()
+      reply.iterateFilesOrThrowIfEmpty { _, replyFile -> replyFiles += replyFile }
+
+      replyFiles.forEachIndexed { fileIndex, replyFile ->
         val replyFileMetaResult = replyFile.getReplyFileMeta()
         if (replyFileMetaResult is ModularResult.Error<*>) {
           throw IOException((replyFileMetaResult as ModularResult.Error<ReplyFileMeta>).error)
@@ -162,7 +174,7 @@ class LynxchanReplyHttpCall(
     return formBuilder
   }
 
-  private fun attachFile(
+  private suspend fun attachFile(
     formBuilder: MultipartBody.Builder,
     fileIndex: Int,
     totalFiles: Int,
@@ -172,6 +184,9 @@ class LynxchanReplyHttpCall(
   ) {
     val mediaType = "application/octet-stream".toMediaType()
     val fileOnDisk = replyFile.fileOnDisk
+    val (fileMime, fileSha256) = deriveFileMetadata(fileOnDisk, replyFileMeta.fileName)
+
+    addFileMetadata(formBuilder, replyFileMeta.fileName, fileMime, fileSha256, replyFileMeta.spoiler)
 
     val requestBody = if (progressListener == null) {
       replyFile.fileOnDisk.asRequestBody(mediaType)
@@ -451,5 +466,50 @@ class LynxchanReplyHttpCall(
     private const val TAG = "LynxchanReplyHttpCall"
 
     private val GENERIC_ERROR_PATTERN = Pattern.compile("<\\w+>(Error:.*?)<\\/\\w+>")
+
+    internal suspend fun deriveFileMetadata(
+      file: java.io.File,
+      finalFileName: String,
+      dispatcher: CoroutineDispatcher = Dispatchers.IO
+    ): Pair<String, String> = withContext(dispatcher) {
+      val mime = when (MediaUtils.getImageFormat(file)) {
+        Bitmap.CompressFormat.PNG -> "image/png"
+        Bitmap.CompressFormat.JPEG -> "image/jpeg"
+        Bitmap.CompressFormat.WEBP -> "image/webp"
+        else -> StringUtils.extractFileNameExtension(finalFileName)
+          ?.lowercase(Locale.ENGLISH)
+          ?.let(MimeTypeMap.getSingleton()::getMimeTypeFromExtension)
+          ?: "application/octet-stream"
+      }
+
+      mime to file.inputStream().use { input -> calculateSha256(input) }
+    }
+
+    internal suspend fun calculateSha256(input: InputStream): String {
+      val digest = MessageDigest.getInstance("SHA-256")
+      val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
+
+      while (true) {
+        currentCoroutineContext().ensureActive()
+        val read = input.read(buffer)
+        if (read < 0) break
+        digest.update(buffer, 0, read)
+      }
+
+      return digest.digest().joinToString("") { byte -> "%02x".format(byte) }
+    }
+
+    internal fun addFileMetadata(
+      formBuilder: MultipartBody.Builder,
+      fileName: String,
+      fileMime: String,
+      fileSha256: String,
+      spoiler: Boolean
+    ) {
+      formBuilder.addFormDataPart("fileName", fileName)
+      formBuilder.addFormDataPart("fileMime", fileMime)
+      formBuilder.addFormDataPart("fileSha256", fileSha256)
+      formBuilder.addFormDataPart("fileSpoiler", if (spoiler) "true" else "")
+    }
   }
 }

--- a/Kuroba/app/src/test/java/com/github/k1rakishou/chan/core/site/sites/lynxchan/engine/LynxchanPostingContractTest.kt
+++ b/Kuroba/app/src/test/java/com/github/k1rakishou/chan/core/site/sites/lynxchan/engine/LynxchanPostingContractTest.kt
@@ -1,0 +1,141 @@
+package com.github.k1rakishou.chan.core.site.sites.lynxchan.engine
+
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.asCoroutineDispatcher
+import kotlinx.coroutines.job
+import kotlinx.coroutines.test.runTest
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.MultipartBody
+import okhttp3.RequestBody.Companion.toRequestBody
+import okio.Buffer
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import java.io.ByteArrayInputStream
+import java.util.concurrent.Executors
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.coroutines.CoroutineContext
+
+@RunWith(RobolectricTestRunner::class)
+class LynxchanPostingContractTest {
+  @get:Rule
+  val temporaryFolder = TemporaryFolder()
+
+  @Test
+  fun `board mapping enables image spoilers`() {
+    val boardData = LynxchanGetBoardsUseCase.LynxchanBoardsData(
+      boardUri = "test",
+      boardName = "Test board",
+      boardDescription = null,
+      tags = listOf("sfw"),
+      specialSettings = null
+    )
+
+    assertTrue(boardData.supportsImageSpoilers)
+  }
+
+  @Test
+  fun `multipart metadata preserves mixed per-file spoiler flags`() {
+    val formBuilder = MultipartBody.Builder().setType(MultipartBody.FORM)
+    addFile(formBuilder, "spoilered.png", "image/png", "sha256-a", spoiler = true)
+    addFile(formBuilder, "plain.jpg", "image/jpeg", "sha256-b", spoiler = false)
+
+    val buffer = Buffer()
+    formBuilder.build().writeTo(buffer)
+    val multipartBody = buffer.readUtf8()
+
+    assertEquals(listOf("spoilered.png", "plain.jpg"), fieldValues(multipartBody, "fileName"))
+    assertEquals(listOf("image/png", "image/jpeg"), fieldValues(multipartBody, "fileMime"))
+    assertEquals(listOf("sha256-a", "sha256-b"), fieldValues(multipartBody, "fileSha256"))
+    assertEquals(listOf("true", ""), fieldValues(multipartBody, "fileSpoiler"))
+    assertTrue(multipartBody.indexOf("name=\"fileSpoiler\"") < multipartBody.indexOf("name=\"files\""))
+  }
+
+  @Test
+  fun `metadata uses final PNG bytes and calculates SHA-256 off caller dispatcher`() = runTest {
+    val pngBytes = byteArrayOf(-119, 80, 78, 71, 13, 10, 26, 10, 1, 2, 3)
+    val file = temporaryFolder.newFile("reencoded-file").apply { writeBytes(pngBytes) }
+    val executor = Executors.newSingleThreadExecutor()
+    val delegate = executor.asCoroutineDispatcher()
+    val dispatcher = CountingDispatcher(delegate)
+
+    try {
+      val (mime, sha256) = LynxchanReplyHttpCall.deriveFileMetadata(file, "original.JPG", dispatcher)
+
+      assertEquals("image/png", mime)
+      assertEquals("7f47b756761a46e6d4a4d96f0d8a4448f8449235009d1f3ad1493f5c773c19e8", sha256)
+      assertTrue(dispatcher.dispatchCount.get() > 0)
+    } finally {
+      delegate.close()
+      executor.shutdownNow()
+    }
+  }
+
+  @Test
+  fun `metadata normalizes uppercase extension and falls back for unknown content`() = runTest {
+    val file = temporaryFolder.newFile("unknown-content").apply { writeText("not an image") }
+
+    assertEquals("image/jpeg", LynxchanReplyHttpCall.deriveFileMetadata(file, "final.JPEG").first)
+    assertEquals("application/octet-stream", LynxchanReplyHttpCall.deriveFileMetadata(file, "final.unknown").first)
+  }
+
+  @Test
+  fun `SHA-256 checks cancellation between chunks`() = runTest {
+    val hashing = async(Dispatchers.Default) {
+      val job = coroutineContext.job
+      val input = object : ByteArrayInputStream(ByteArray(DEFAULT_BUFFER_SIZE * 2)) {
+        override fun read(buffer: ByteArray, offset: Int, length: Int): Int {
+          return super.read(buffer, offset, length).also { job.cancel() }
+        }
+      }
+
+      LynxchanReplyHttpCall.calculateSha256(input)
+    }
+
+    try {
+      hashing.await()
+      fail("Expected SHA-256 calculation to be cancelled")
+    } catch (_: CancellationException) {
+      // Expected: the next chunk boundary observes cancellation.
+    }
+  }
+
+  private fun addFile(
+    formBuilder: MultipartBody.Builder,
+    fileName: String,
+    fileMime: String,
+    fileSha256: String,
+    spoiler: Boolean
+  ) {
+    LynxchanReplyHttpCall.addFileMetadata(formBuilder, fileName, fileMime, fileSha256, spoiler)
+    formBuilder.addFormDataPart(
+      "files",
+      fileName,
+      fileName.toRequestBody("application/octet-stream".toMediaType())
+    )
+  }
+
+  private fun fieldValues(multipartBody: String, fieldName: String): List<String> {
+    val pattern = Regex("name=\\\"${fieldName}\\\"\\r\\n(?:Content-[^\\r]+\\r\\n)*\\r\\n(.*?)\\r\\n")
+    return pattern.findAll(multipartBody).map { match -> match.groupValues[1] }.toList()
+  }
+
+  private class CountingDispatcher(
+    private val delegate: CoroutineDispatcher
+  ) : CoroutineDispatcher() {
+    val dispatchCount = AtomicInteger()
+
+    override fun dispatch(context: CoroutineContext, block: Runnable) {
+      dispatchCount.incrementAndGet()
+      delegate.dispatch(context, block)
+    }
+  }
+}


### PR DESCRIPTION
## What does this PR do?

Enables the existing per-file image-spoiler control for Lynxchan boards and sends the required indexed file metadata when posting through Lynxchan's multipart path.

Each attachment now carries its final filename, MIME type, SHA-256, and spoiler flag alongside the uploaded file. MIME detection uses the final bytes after re-encoding, while hashing runs off the main thread and remains cooperatively cancellable.

## Related issue

Closes #1131

## How was this tested?

- 5 focused Lynxchan contract tests cover board capability, mixed spoiler flags, final-byte MIME detection, SHA-256, extension fallbacks, dispatcher handoff, and cancellation.
- `:app:detekt` passes.
- `:app:compileDebugKotlin` passes.
- Tracked and untracked diff checks pass.
- Manual live 8chan posting was blocked by POWBlock.
