### PR TITLE
fix(media): release screen timeout for images

### DIFF
--- a/Kuroba/app/src/main/java/com/github/k1rakishou/chan/features/view/media/MediaViewerActivity.kt
+++ b/Kuroba/app/src/main/java/com/github/k1rakishou/chan/features/view/media/MediaViewerActivity.kt
@@ -6,7 +6,6 @@ import android.content.res.Configuration
 import android.graphics.Point
 import android.os.Bundle
 import android.view.MotionEvent
-import android.view.WindowManager
 import android.webkit.URLUtil
 import androidx.core.os.bundleOf
 import androidx.lifecycle.lifecycleScope
@@ -26,7 +25,6 @@ import com.github.k1rakishou.chan.utils.FullScreenUtils.setupEdgeToEdge
 import com.github.k1rakishou.chan.utils.FullScreenUtils.setupStatusAndNavBarColors
 import com.github.k1rakishou.chan.utils.startActivitySafe
 import com.github.k1rakishou.chan.utils.viewModelByKey
-import com.github.k1rakishou.common.AndroidUtils
 import com.github.k1rakishou.core_logger.Logger
 import com.github.k1rakishou.core_themes.ThemeEngine
 import com.github.k1rakishou.fsaf.FileChooser
@@ -89,9 +87,6 @@ class MediaViewerActivity :
       .build()
 
     initView(findViewById(android.R.id.content))
-
-    AndroidUtils.getWindow(this)
-      ?.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
 
     mediaViewerController = MediaViewerController(
       context = this,
@@ -167,9 +162,6 @@ class MediaViewerActivity :
     if (::globalWindowInsetsManager.isInitialized) {
       globalWindowInsetsManager.stopListeningForWindowInsetsChanges(window)
     }
-
-    AndroidUtils.getWindow(this)
-      ?.clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
   }
 
   override fun finish() {

--- a/Kuroba/app/src/main/java/com/github/k1rakishou/chan/features/view/media/element/MediaView.kt
+++ b/Kuroba/app/src/main/java/com/github/k1rakishou/chan/features/view/media/element/MediaView.kt
@@ -192,6 +192,7 @@ abstract class MediaView<T : ViewableMedia, S : MediaViewState> constructor(
     isLifecycleChange: Boolean
   ) {
     _shown = true
+    keepScreenOn = viewableMedia is ViewableMedia.Video
     this._mediaViewToolbar = mediaViewerToolbar
     this._mediaViewToolbar!!.attach(mediaViewContract.viewerChanDescriptor, viewableMedia, this)
 
@@ -209,6 +210,7 @@ abstract class MediaView<T : ViewableMedia, S : MediaViewState> constructor(
 
   fun onHide(isLifecycleChange: Boolean, isPausing: Boolean, isBecomingInactive: Boolean) {
     _shown = false
+    keepScreenOn = false
     this._mediaViewToolbar?.detach()
     this._mediaViewToolbar = null
 
@@ -235,6 +237,7 @@ abstract class MediaView<T : ViewableMedia, S : MediaViewState> constructor(
     _shown = false
     _bound = false
     _preloadingCalled = false
+    keepScreenOn = false
     _mediaViewToolbar?.onDestroy()
     mediaViewerActionStrip?.onDestroy()
 


### PR DESCRIPTION
## What does this PR do?

Allows the device screen timeout to work while static images, GIFs, or audio are open in the media viewer.

Videos continue to keep the display awake while visible. The screen-on state is now owned by the active video view and is released when that view is hidden, recycled, or backgrounded.

## Related issue

Closes #978

## How was this tested?

- `:app:compileDebugKotlin`
- `:app:detekt`
- `:app:testDebugUnitTest`
- `:app:assembleDebug`
- Android API 36 emulator:
  - a static image followed the configured five-second screen timeout;
  - video set `KEEP_SCREEN_ON`;
  - repeated video-to-image transitions cleared it;
  - backgrounding cleared it and resuming video restored it.

The optional MPV plugin was not separately installed, but its video view uses the same common lifecycle covered by this change.
