### PR TITLE
fix: preserve nested quote and link colors

### DIFF
--- a/Kuroba/app/src/main/java/com/github/k1rakishou/chan/core/site/parser/CommentParser.kt
+++ b/Kuroba/app/src/main/java/com/github/k1rakishou/chan/core/site/parser/CommentParser.kt
@@ -137,7 +137,11 @@ open class CommentParser(
     )
 
     addRule(StyleRule.tagRule("span").withCssClass("abbr").nullify())
-    addRule(StyleRule.tagRule("span").foregroundColorId(ChanThemeColorId.PostInlineQuoteColor))
+    addRule(
+      StyleRule.tagRule("span")
+        .foregroundColorId(ChanThemeColorId.PostInlineQuoteColor)
+        .withSpanPriority(255)
+    )
     addRule(StyleRule.tagRule("span").withoutAnyOfCssClass("quote").linkify())
 
     addRule(StyleRule.tagRule("strong").bold())

--- a/Kuroba/app/src/main/java/com/github/k1rakishou/chan/core/site/parser/style/StyleRule.kt
+++ b/Kuroba/app/src/main/java/com/github/k1rakishou/chan/core/site/parser/style/StyleRule.kt
@@ -48,6 +48,7 @@ class StyleRule {
   private var blockElement = false
   private var newLine = false
   private var priority: Priority? = Priority.Normal
+  private var spanPriority = 1000
 
   fun rulePriority(): Priority? {
     return priority
@@ -69,6 +70,12 @@ class StyleRule {
 
   fun withPriority(newPriority: Priority): StyleRule {
     this.priority = newPriority
+    return this
+  }
+
+  fun withSpanPriority(newSpanPriority: Int): StyleRule {
+    require(newSpanPriority in 0..255) { "Span priority must be between 0 and 255" }
+    this.spanPriority = newSpanPriority
     return this
   }
 
@@ -332,7 +339,7 @@ class StyleRule {
           span,
           0,
           result.length,
-          (1000 shl Spanned.SPAN_PRIORITY_SHIFT) and Spanned.SPAN_PRIORITY
+          (spanPriority shl Spanned.SPAN_PRIORITY_SHIFT) and Spanned.SPAN_PRIORITY
         )
       }
     }

--- a/Kuroba/app/src/test/java/com/github/k1rakishou/chan/core/site/parser/style/StyleRuleTest.kt
+++ b/Kuroba/app/src/test/java/com/github/k1rakishou/chan/core/site/parser/style/StyleRuleTest.kt
@@ -1,0 +1,108 @@
+package com.github.k1rakishou.chan.core.site.parser.style
+
+import android.text.SpannableStringBuilder
+import android.text.Spanned
+import android.text.style.CharacterStyle
+import com.github.k1rakishou.core_parser.comment.HtmlTag
+import com.github.k1rakishou.core_spannable.ForegroundColorIdSpan
+import com.github.k1rakishou.core_spannable.PostLinkable
+import com.github.k1rakishou.core_themes.ChanThemeColorId
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertThrows
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class StyleRuleTest {
+  @Test
+  fun `nested links are drawn after the inline quote color`() {
+    val text = SpannableStringBuilder("plain ")
+    val quoteStart = text.length
+    val quote = PostLinkable(
+      key = ">>123",
+      linkableValue = PostLinkable.Value.PostIdValue(123L, 0L),
+      type = PostLinkable.Type.QUOTE,
+      revealTextSpoilers = false
+    )
+    text.append(quote.key)
+    text.setSpan(quote, quoteStart, text.length, spanFlags(250))
+
+    text.append(" ")
+    val autoLinkStart = text.length
+    val autoLink = PostLinkable(
+      key = "https://example.com",
+      linkableValue = PostLinkable.Value.StringValue("https://example.com"),
+      type = PostLinkable.Type.LINK,
+      revealTextSpoilers = false
+    )
+    text.append(autoLink.key)
+    text.setSpan(autoLink, autoLinkStart, text.length, spanFlags(500))
+
+    val result = checkNotNull(
+      StyleRule.tagRule("span")
+        .foregroundColorId(ChanThemeColorId.PostInlineQuoteColor)
+        .withSpanPriority(255)
+        .apply(styleRulesParams(text))
+    ) as Spanned
+
+    val inlineQuoteSpan = result
+      .getSpans(0, result.length, ForegroundColorIdSpan::class.java)
+      .single()
+    assertEquals(ChanThemeColorId.PostInlineQuoteColor, inlineQuoteSpan.chanThemeColorId)
+    assertEquals(255, spanPriority(result, inlineQuoteSpan))
+    assertEquals(250, spanPriority(result, quote))
+    assertEquals(244, spanPriority(result, autoLink))
+    assertEquals(listOf(inlineQuoteSpan), characterStylesAt(result, 0))
+
+    // CharacterStyle spans are returned in draw order, so the nested color is applied last.
+    val quoteStyles = characterStylesAt(result, quoteStart)
+    assertSame(inlineQuoteSpan, quoteStyles.first())
+    assertSame(quote, quoteStyles.last())
+
+    val autoLinkStyles = characterStylesAt(result, autoLinkStart)
+    assertSame(inlineQuoteSpan, autoLinkStyles.first())
+    assertSame(autoLink, autoLinkStyles.last())
+  }
+
+  @Test
+  fun `span priority must fit in Android priority bits`() {
+    assertThrows(IllegalArgumentException::class.java) {
+      StyleRule.tagRule("span").withSpanPriority(-1)
+    }
+    assertThrows(IllegalArgumentException::class.java) {
+      StyleRule.tagRule("span").withSpanPriority(256)
+    }
+  }
+
+  private fun characterStylesAt(text: Spanned, offset: Int): List<CharacterStyle> {
+    return text.getSpans(offset, offset + 1, CharacterStyle::class.java).toList()
+  }
+
+  private fun spanFlags(priority: Int): Int {
+    return (priority shl Spanned.SPAN_PRIORITY_SHIFT) and Spanned.SPAN_PRIORITY
+  }
+
+  private fun spanPriority(text: Spanned, span: Any): Int {
+    return (text.getSpanFlags(span) and Spanned.SPAN_PRIORITY) shr Spanned.SPAN_PRIORITY_SHIFT
+  }
+
+  private fun styleRulesParams(text: CharSequence): StyleRulesParams {
+    return StyleRulesParams(
+      text = text,
+      htmlTag = HtmlTag(
+        index = 0,
+        parentNode = null,
+        tagName = "span",
+        attributes = emptyList(),
+        children = emptyList(),
+        isVoidElement = false
+      ),
+      callback = null,
+      post = null,
+      forceHttpsScheme = true,
+      revealTextSpoilers = false
+    )
+  }
+}


### PR DESCRIPTION
## Summary

- allow individual style rules to choose a validated Android span priority while preserving the existing default
- give inline-quote color the highest priority so nested quote and link colors are applied afterward
- add focused coverage for nested quote and auto-link ordering and invalid priorities

## Validation

- `ANDROID_HOME=/Users/arpitagarwal/Library/Android/sdk bash ./gradlew :app:testDebugUnitTest --tests 'com.github.k1rakishou.chan.core.site.parser.style.StyleRuleTest' --rerun-tasks --no-daemon`
- `git diff --check`

Fixes #1049
