### PR TITLE
fix: bookmark threads when saving own posts

### DIFF
--- a/Kuroba/app/src/main/java/com/github/k1rakishou/chan/core/manager/SavedReplyManager.kt
+++ b/Kuroba/app/src/main/java/com/github/k1rakishou/chan/core/manager/SavedReplyManager.kt
@@ -158,7 +158,7 @@ class SavedReplyManager(
     _savedRepliesUpdateFlow.tryEmit(Unit)
   }
 
-  suspend fun savePost(postDescriptor: PostDescriptor) {
+  suspend fun savePost(postDescriptor: PostDescriptor): Boolean {
     val post = chanThreadsCache.getThreadPostFromCache(postDescriptor)
 
     val comment = post?.postComment?.originalComment()?.toString()
@@ -172,16 +172,16 @@ class SavedReplyManager(
       subject = subject
     )
 
-    saveReply(savedReply)
+    return saveReply(savedReply)
   }
 
-  suspend fun saveReply(savedReply: ChanSavedReply) {
+  suspend fun saveReply(savedReply: ChanSavedReply): Boolean {
     val postDescriptor = savedReply.postDescriptor
 
     savedReplyRepository.savePost(savedReply)
       .safeUnwrap { error ->
         Logger.e(TAG, "savePost($postDescriptor) error", error)
-        return
+        return false
       }
 
     val updated = lock.write {
@@ -199,6 +199,8 @@ class SavedReplyManager(
     if (updated) {
       _savedRepliesUpdateFlow.tryEmit(Unit)
     }
+
+    return true
   }
 
   fun retainSavedPostNoMap(

--- a/Kuroba/app/src/main/java/com/github/k1rakishou/chan/core/presenter/ThreadPresenter.kt
+++ b/Kuroba/app/src/main/java/com/github/k1rakishou/chan/core/presenter/ThreadPresenter.kt
@@ -985,7 +985,17 @@ class ThreadPresenter @Inject constructor(
       return true
     }
 
-    if (!isBound) {
+    return createBookmarkIfNotExists(threadDescriptor)
+  }
+
+  private suspend fun createBookmarkIfNotExists(
+    threadDescriptor: ChanDescriptor.ThreadDescriptor
+  ): Boolean {
+    if (bookmarksManager.contains(threadDescriptor)) {
+      return true
+    }
+
+    if (!bookmarksManager.isReady() || !isBound) {
       return false
     }
 
@@ -2581,11 +2591,16 @@ class ThreadPresenter @Inject constructor(
   }
 
   private suspend fun saveUnsavePost(post: ChanPost) {
-    if (savedReplyManager.isSaved(post.postDescriptor)) {
-      savedReplyManager.unsavePost(post.postDescriptor)
-    } else {
-      savedReplyManager.savePost(post.postDescriptor)
-    }
+    val isSaving = !savedReplyManager.isSaved(post.postDescriptor)
+
+    saveUnsavePostAndBookmarkThread(
+      postDescriptor = post.postDescriptor,
+      isSaving = isSaving,
+      savePost = savedReplyManager::savePost,
+      unsavePost = savedReplyManager::unsavePost,
+      shouldCreateBookmark = { kurobaSettings.application.postPinThread.read() },
+      createBookmarkIfNotExists = this::createBookmarkIfNotExists
+    )
 
     // Trigger onDemandContentLoaderManager for this post again
     onDemandContentLoaderManager.onPostUnbind(post.postDescriptor, isActuallyRecycling = true)
@@ -3160,4 +3175,26 @@ class ThreadPresenter @Inject constructor(
     const val SCROLL_TO_POST_DELAY_MS = 125L
   }
 
+}
+
+internal suspend fun saveUnsavePostAndBookmarkThread(
+  postDescriptor: PostDescriptor,
+  isSaving: Boolean,
+  savePost: suspend (PostDescriptor) -> Boolean,
+  unsavePost: suspend (PostDescriptor) -> Unit,
+  shouldCreateBookmark: suspend () -> Boolean,
+  createBookmarkIfNotExists: suspend (ChanDescriptor.ThreadDescriptor) -> Boolean
+) {
+  if (!isSaving) {
+    unsavePost(postDescriptor)
+    return
+  }
+
+  if (!savePost(postDescriptor)) {
+    return
+  }
+
+  if (shouldCreateBookmark()) {
+    createBookmarkIfNotExists(postDescriptor.threadDescriptor())
+  }
 }

--- a/Kuroba/app/src/test/java/com/github/k1rakishou/chan/core/presenter/ThreadPresenterBookmarkOrchestrationTest.kt
+++ b/Kuroba/app/src/test/java/com/github/k1rakishou/chan/core/presenter/ThreadPresenterBookmarkOrchestrationTest.kt
@@ -1,0 +1,103 @@
+package com.github.k1rakishou.chan.core.presenter
+
+import com.github.k1rakishou.model.data.descriptor.ChanDescriptor
+import com.github.k1rakishou.model.data.descriptor.PostDescriptor
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ThreadPresenterBookmarkOrchestrationTest {
+  private val catalogDescriptor = ChanDescriptor.CatalogDescriptor.create("test", "test")
+  private val threadDescriptor = ChanDescriptor.ThreadDescriptor.create(catalogDescriptor, 1L)
+  private val postDescriptor = PostDescriptor.create(threadDescriptor, 2L)
+
+  @Test
+  fun successfulSaveCreatesBookmarkForPostThread() = runTest {
+    val harness = Harness(postDescriptor)
+
+    harness.execute(isSaving = true)
+
+    assertEquals(listOf(postDescriptor), harness.saveCalls)
+    assertTrue(harness.unsaveCalls.isEmpty())
+    assertEquals(listOf(threadDescriptor), harness.createdBookmarks)
+  }
+
+  @Test
+  fun failedSaveDoesNotCreateBookmark() = runTest {
+    val harness = Harness(postDescriptor, saveSucceeds = false)
+
+    harness.execute(isSaving = true)
+
+    assertEquals(listOf(postDescriptor), harness.saveCalls)
+    assertTrue(harness.bookmarkRequests.isEmpty())
+  }
+
+  @Test
+  fun unsaveDoesNotTouchExistingBookmark() = runTest {
+    val harness = Harness(postDescriptor, initialBookmarks = setOf(threadDescriptor))
+
+    harness.execute(isSaving = false)
+
+    assertEquals(listOf(postDescriptor), harness.unsaveCalls)
+    assertTrue(harness.saveCalls.isEmpty())
+    assertTrue(harness.bookmarkRequests.isEmpty())
+    assertEquals(setOf(threadDescriptor), harness.bookmarks)
+  }
+
+  @Test
+  fun disabledSettingDoesNotCreateBookmark() = runTest {
+    val harness = Harness(postDescriptor, postPinThreadEnabled = false)
+
+    harness.execute(isSaving = true)
+
+    assertEquals(listOf(postDescriptor), harness.saveCalls)
+    assertTrue(harness.bookmarkRequests.isEmpty())
+  }
+
+  @Test
+  fun existingBookmarkIsPreserved() = runTest {
+    val harness = Harness(postDescriptor, initialBookmarks = setOf(threadDescriptor))
+
+    harness.execute(isSaving = true)
+
+    assertEquals(listOf(threadDescriptor), harness.bookmarkRequests)
+    assertTrue(harness.createdBookmarks.isEmpty())
+    assertEquals(setOf(threadDescriptor), harness.bookmarks)
+  }
+
+  private class Harness(
+    private val postDescriptor: PostDescriptor,
+    private val saveSucceeds: Boolean = true,
+    private val postPinThreadEnabled: Boolean = true,
+    initialBookmarks: Set<ChanDescriptor.ThreadDescriptor> = emptySet()
+  ) {
+    val saveCalls = mutableListOf<PostDescriptor>()
+    val unsaveCalls = mutableListOf<PostDescriptor>()
+    val bookmarkRequests = mutableListOf<ChanDescriptor.ThreadDescriptor>()
+    val createdBookmarks = mutableListOf<ChanDescriptor.ThreadDescriptor>()
+    val bookmarks = initialBookmarks.toMutableSet()
+
+    suspend fun execute(isSaving: Boolean) {
+      saveUnsavePostAndBookmarkThread(
+        postDescriptor = postDescriptor,
+        isSaving = isSaving,
+        savePost = { descriptor ->
+          saveCalls += descriptor
+          saveSucceeds
+        },
+        unsavePost = { descriptor -> unsaveCalls += descriptor },
+        shouldCreateBookmark = { postPinThreadEnabled },
+        createBookmarkIfNotExists = { descriptor ->
+          bookmarkRequests += descriptor
+
+          if (bookmarks.add(descriptor)) {
+            createdBookmarks += descriptor
+          }
+
+          true
+        }
+      )
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- report whether saved-reply persistence succeeds
- bookmark the post's thread after a successful manual mark-as-own when the setting is enabled
- preserve existing bookmarks and cover save, failure, unsave, disabled, and idempotent behavior

## Validation

- `ANDROID_HOME=/Users/arpitagarwal/Library/Android/sdk bash ./gradlew :app:testDebugUnitTest --tests 'com.github.k1rakishou.chan.core.presenter.ThreadPresenterBookmarkOrchestrationTest' --no-daemon`
- `git diff --check`

Fixes #1050
