### PR TITLE
fix(DvachSiteRequestModifier): add missing modifyGenericRequest()

### DIFF
--- a/Kuroba/app/src/main/java/com/github/k1rakishou/chan/core/site/sites/dvach/DvachSiteRequestModifier.kt
+++ b/Kuroba/app/src/main/java/com/github/k1rakishou/chan/core/site/sites/dvach/DvachSiteRequestModifier.kt
@@ -27,6 +27,13 @@ class DvachSiteRequestModifier(
     addUserCodeCookie(requestBuilder)
   }
 
+  override fun modifyGenericRequest(site: Site, requestBuilder: Request.Builder) {
+    super.modifyGenericRequest(site, requestBuilder)
+
+    addAntiSpamCookie(requestBuilder)
+    addUserCodeCookie(requestBuilder)
+  }
+
   override fun modifyCatalogOrThreadGetRequest(
     site: Site,
     chanDescriptor: ChanDescriptor,


### PR DESCRIPTION
Add missing `modifyGenericRequest()` to `DvachSiteRequestModifier`.
This fixes thread posts and media files failing to load on hidden boards due to missing cookies.