### PR TITLE
display dvach stickers as images

### DIFF
--- a/Kuroba/app/src/main/java/com/github/k1rakishou/chan/core/site/sites/dvach/DvachApi.kt
+++ b/Kuroba/app/src/main/java/com/github/k1rakishou/chan/core/site/sites/dvach/DvachApi.kt
@@ -599,10 +599,6 @@ class DvachApi(
       boardDescriptor: BoardDescriptor,
       endpoints: SiteEndpoints
     ): ChanPostImage? {
-      if (path?.contains("/stickers/", ignoreCase = true) == true) {
-        return null
-      }
-
       var fileExt: String? = null
       var serverFileName: String? = null
 


### PR DESCRIPTION
Why can't stickers be displayed as regular images?

Not sure why they were skipped in the first place since they have all the required image fields and seem to be working fine.